### PR TITLE
Add manifests for core and CLI crates

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "hauski-cli"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "hauski-core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow.workspace = true
+axum.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true


### PR DESCRIPTION
## Summary
- add a Cargo.toml for the hauski-core binary crate with workspace dependencies
- add a Cargo.toml for the hauski CLI crate pointing at shared workspace crates

## Testing
- CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse cargo check *(fails: CONNECT tunnel 403 while fetching crates index)*

------
https://chatgpt.com/codex/tasks/task_e_68d0157a8c2c832cb74e4c55ee5cb25b