### PR TITLE
Fix CI workflow missing toolchain input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: stable
           components: rustfmt, clippy
       - name: Cache cargo
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- provide the required `toolchain` input to the `dtolnay/rust-toolchain` step so the workflow can install the requested Rust toolchain

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d01c2b7650832cb188aad82057c1f9