### PR TITLE
Set default toolchain input for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   rust:
     runs-on: ubuntu-24.04
+    env:
+      toolchain: stable
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- define the `toolchain` environment variable for the CI job so required inputs are always present

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7c73a712c832c9679d43186c2275d