### PR TITLE
Silence explicit auto deref lint in hauski-core

### DIFF
--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -5,6 +5,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 async fn health() -> &'static str { "ok" }
 
+#[allow(clippy::explicit_auto_deref)]
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::registry()


### PR DESCRIPTION
## Summary
- allow the `clippy::explicit_auto_deref` lint on the Tokio main entry point, which is emitted from the macro expansion

## Testing
- cargo clippy -p hauski-core --all-targets -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68d7f3641890832c84b10811aa4151c0