### PR TITLE
Instrument HTTP metrics with labels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 axum = "0.7"
 clap = { version = "4", features = ["derive"] }
 prometheus-client = "0.22"
+tabled = "0.15"
 # sqlx bewusst nicht vorgezogen, bis erste DB-Crate existiert

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -1,5 +1,10 @@
-use axum::{extract::State, routing::get, Json, Router};
-use std::{net::SocketAddr, sync::Arc};
+use axum::{
+    extract::State,
+    http::{Method, StatusCode},
+    routing::get,
+    Json, Router,
+};
+use std::{fmt, net::SocketAddr, sync::Arc};
 use tokio::net::TcpListener;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -16,14 +21,66 @@ use crate::config::{load_limits, load_models, Limits, ModelsFile};
 struct AppState {
     limits: Arc<Limits>,
     models: Arc<ModelsFile>,
+    registry: Arc<Registry>,
+    http_requests_total: Family<HttpLabels, Counter>,
 }
 
 async fn get_limits(State(state): State<AppState>) -> Json<Limits> {
+    state.record_http_request(Method::GET, "/config/limits", StatusCode::OK);
     Json((*state.limits).clone())
 }
 
 async fn get_models(State(state): State<AppState>) -> Json<ModelsFile> {
+    state.record_http_request(Method::GET, "/config/models", StatusCode::OK);
     Json((*state.models).clone())
+}
+
+async fn health(State(state): State<AppState>) -> &'static str {
+    state.record_http_request(Method::GET, "/health", StatusCode::OK);
+    "ok"
+}
+
+async fn metrics(State(state): State<AppState>) -> String {
+    let mut body = String::new();
+    encode(&mut body, &*state.registry).expect("encode metrics");
+    state.record_http_request(Method::GET, "/metrics", StatusCode::OK);
+    body
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct HttpLabels {
+    method: Method,
+    path: &'static str,
+    status: StatusCode,
+}
+
+impl HttpLabels {
+    fn new(method: Method, path: &'static str, status: StatusCode) -> Self {
+        Self {
+            method,
+            path,
+            status,
+        }
+    }
+}
+
+impl prometheus_client::encoding::text::EncodeLabelSet for HttpLabels {
+    fn encode(
+        &self,
+        mut encoder: prometheus_client::encoding::LabelSetEncoder<'_>,
+    ) -> Result<(), fmt::Error> {
+        encoder.encode_label("method", self.method.as_str())?;
+        encoder.encode_label("path", self.path)?;
+        encoder.encode_label("status", self.status.as_str())?;
+        Ok(())
+    }
+}
+
+impl AppState {
+    fn record_http_request(&self, method: Method, path: &'static str, status: StatusCode) {
+        let labels = HttpLabels::new(method, path, status);
+        self.http_requests_total.get_or_create(&labels).inc();
+    }
 }
 
 #[allow(clippy::explicit_auto_deref)]
@@ -39,7 +96,7 @@ async fn main() -> anyhow::Result<()> {
     build_info.get_or_create(&()).set(1);
     registry.register("hauski_build_info", "static 1", build_info);
 
-    let http_requests_total = Counter::<u64>::default();
+    let http_requests_total = Family::<HttpLabels, Counter>::default();
     registry.register(
         "http_requests_total",
         "Total number of HTTP requests received",
@@ -47,7 +104,6 @@ async fn main() -> anyhow::Result<()> {
     );
 
     let registry = Arc::new(registry);
-    let metrics_registry = registry.clone();
 
     let limits_path =
         std::env::var("HAUSKI_LIMITS").unwrap_or_else(|_| "./policies/limits.yaml".to_string());
@@ -55,28 +111,16 @@ async fn main() -> anyhow::Result<()> {
         std::env::var("HAUSKI_MODELS").unwrap_or_else(|_| "./configs/models.yml".to_string());
     let limits = Arc::new(load_limits(&limits_path)?);
     let models = Arc::new(load_models(&models_path)?);
-    let app_state = AppState { limits, models };
-
-    let metrics = get(move || {
-        let registry = metrics_registry.clone();
-        async move {
-            let mut body = String::new();
-            encode(&mut body, &*registry).expect("encode metrics");
-            body
-        }
-    });
-
-    let health_route = get(move || {
-        let counter = http_requests_total.clone();
-        async move {
-            counter.inc();
-            "ok"
-        }
-    });
+    let app_state = AppState {
+        limits,
+        models,
+        registry: registry.clone(),
+        http_requests_total,
+    };
 
     let app = Router::new()
-        .route("/health", health_route)
-        .route("/metrics", metrics)
+        .route("/health", get(health))
+        .route("/metrics", get(metrics))
         .route("/config/limits", get(get_limits))
         .route("/config/models", get(get_models))
         .with_state(app_state);
@@ -85,6 +129,6 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("listening on http://{addr}");
 
     let listener = TcpListener::bind(addr).await?;
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app.into_make_service()).await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add the missing `tabled` workspace dependency required by the CLI crate
- expose HTTP request metrics as a labeled counter family and implement `EncodeLabelSet` for `HttpLabels`
- serve the router with shared application state while recording metrics in each handler

## Testing
- cargo fmt
- cargo check *(fails: crates.io index blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8bed0a0d4832ca25eddcd8333b349