### PR TITLE
Remove unnecessary into_make_service call

### DIFF
--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -129,6 +129,6 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("listening on http://{addr}");
 
     let listener = TcpListener::bind(addr).await?;
-    axum::serve(listener, app.into_make_service()).await?;
+    axum::serve(listener, app).await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- update the axum server startup to pass the router directly instead of converting it into a service

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8c7b53c44832ca725eba8c4cd1290