### PR TITLE
Fix cargo-deny configuration sections

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,9 +1,20 @@
+[advisories]
+default = "deny"
+
 [licenses]
 unlicensed = "deny"
-allow = ["MIT", "Apache-2.0", "BSD-3-Clause", "BSD-2-Clause", "ISC", "Unicode-DFS-2016"]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "BSD-2-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+]
 default = "deny"
 confidence-threshold = 0.8
 
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
+


### PR DESCRIPTION
## Summary
- add an advisories table so the cargo-deny configuration parses correctly
- reformat the license allow list and ensure the file ends with a newline

## Testing
- not run (cargo-deny not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8e9339480832c98b4dc013422bf58