### PR TITLE
Speed up CI tool installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,14 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
-      - name: Cache cargo
-        uses: actions/cache@v4
+      - uses: taiki-e/install-action@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install cargo-deny and just
-        run: cargo install cargo-deny just
+          tool: cargo-deny
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
       - name: fmt
         run: cargo fmt --all --check
       - name: clippy


### PR DESCRIPTION
## Summary
- install cargo-deny and just via taiki-e/install-action to avoid long build steps that stalled CI
- swap manual cargo cache for Swatinem/rust-cache for more reliable target and registry caching

## Testing
- not run (CI workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d8eca99f5c832c801b2c9c63f0f1ee