### PR TITLE
Configure workspace dependencies for core and CLI crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ anyhow = "1"
 thiserror = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "ansi"] }
+tracing-appender = "0.2"
+once_cell = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
@@ -21,5 +23,5 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 axum = "0.7"
 clap = { version = "4", features = ["derive"] }
 prometheus-client = "0.22"
-tabled = "0.15"
+walkdir = "2"
 # sqlx bewusst nicht vorgezogen, bis erste DB-Crate existiert

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -6,5 +6,4 @@ edition = "2021"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-serde.workspace = true
-serde_yaml.workspace = true
+hauski-core = { path = "../core" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -5,14 +5,18 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
+thiserror.workspace = true
 axum.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+tracing-appender.workspace = true
+once_cell.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 prometheus-client.workspace = true
+walkdir.workspace = true
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }


### PR DESCRIPTION
## Summary
- add shared workspace dependencies for tracing, serialization, and filesystem utilities
- align core crate to use the workspace-managed dependencies
- adjust CLI crate to depend on the core crate

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d907579f6c832ca19bd3acfea06712