### PR TITLE
Add dirs dependency to hauski-core

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -17,7 +17,7 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 prometheus-client.workspace = true
 walkdir.workspace = true
-dirs = "5"
+dirs.workspace = true
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }


### PR DESCRIPTION
## Summary
- add the dirs crate as a direct dependency of the core crate so its usage in the configuration module resolves

## Testing
- cargo check -p hauski-core *(fails: unable to download crates.io index in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d909b303c0832cacc9eb2f929bfded