### PR TITLE
docs: clarify wgx env override naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ cargo test --workspace -- --nocapture
 - Prüfe das Manifest vor Commits lokal mit `wgx validate --profile .wgx/profile.yml`.
 - Die JSON-Ansicht der Tasks erhältst du über `wgx tasks --json`.
 - Persönliche Overrides (Pfade, Log-Level, Tokens) gehören in `.wgx/profile.local.yml`; eine Vorlage findest du in `.wgx/profile.local.example.yml`. Die Datei ist git-ignored.
+- Gemeinsame Umgebungsvariablen landen im Manifest unter `envDefaults`, individuelle Anpassungen im lokalen Profil via `envOverrides`. So bleibt die Naming-Convention repo-weit konsistent.
 
 ---
 


### PR DESCRIPTION
## Summary
- document how envDefaults and envOverrides split shared versus local environment variables in the wgx manifest documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d949392940832c831529016b4ca382