### PR TITLE
Grant pull request read permissions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- add the pull-requests read permission to the CI workflow so jobs can access PR metadata

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68da017ba2bc832caed316c3b2aa1893