### PR TITLE
fix: korrigiere escape-sequenzen in vale-regeln

### DIFF
--- a/.vale/styles/hauski/GermanProse/GermanProse.yml
+++ b/.vale/styles/hauski/GermanProse/GermanProse.yml
@@ -5,7 +5,7 @@ scope: text
 ignorecase: true
 nonword: true
 tokens:
-  - "\w+[*:·_]\w+"
-  - "\\b\w+Innen\\b"
-  - "\\b\w+:innen\\b"
-  - "\\b\w+\(\w+in\)\\b"
+  - "\\w+[*:·_]\\w+"
+  - "\\b\\w+Innen\\b"
+  - "\\b\\w+:innen\\b"
+  - "\\b\\w+\(\\w+in\)\\b"


### PR DESCRIPTION
## Summary
- escape die Vale-Regex-Tokens in GermanProse korrekt, damit YAML-Parsing wieder funktioniert

## Testing
- not run (vale nicht verfügbar im Container)


------
https://chatgpt.com/codex/tasks/task_e_68dad9f9f6dc832cb232999ed6c93c98