### PR TITLE
Fix Unicode width handling for CLI models table headers

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -106,12 +106,7 @@ fn print_models_table(file: &ModelsFile) {
     const HEADERS: [&str; 4] = ["ID", "Path", "VRAM Min", "Canary"];
 
     let mut rows: Vec<[String; 4]> = Vec::new();
-    let mut widths = [
-        HEADERS[0].len(),
-        HEADERS[1].len(),
-        HEADERS[2].len(),
-        HEADERS[3].len(),
-    ];
+    let mut widths = HEADERS.map(|header| header.chars().count());
 
     for model in &file.models {
         let vram = model


### PR DESCRIPTION
## Summary
- compute the models table header widths using character counts so the columns stay aligned with Unicode text

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dbf4348b0c832cbdd9a98e6d8b14ee