### PR TITLE
Fix Vale style regex escaping

### DIFF
--- a/.vale/styles/hauski/GermanComments/GermanComments.yml
+++ b/.vale/styles/hauski/GermanComments/GermanComments.yml
@@ -5,5 +5,5 @@ scope: comment
 ignorecase: true
 nonword: true
 tokens:
-  - "[ÄÖÜäöüß]"
-  - "(?<!\\w)(?:und|oder|nicht|kein|sollte|würde|könnte|muss|auf|für|mit|ohne|dass|des|der|die|das|wir|du|euer|ihr)(?!\\w)"
+  - '[ÄÖÜäöüß]'
+  - '(?<!\w)(?:und|oder|nicht|kein|sollte|würde|könnte|muss|auf|für|mit|ohne|dass|des|der|die|das|wir|du|euer|ihr)(?!\w)'

--- a/.vale/styles/hauski/GermanProse/GermanProse.yml
+++ b/.vale/styles/hauski/GermanProse/GermanProse.yml
@@ -5,7 +5,7 @@ scope: text
 ignorecase: true
 nonword: true
 tokens:
-  - "\\w+[*:·_]\\w+"
-  - "\\b\\w+Innen\\b"
-  - "\\b\\w+:innen\\b"
-  - "\\b\\w+\(\\w+in\)\\b"
+  - '\w+[*:·_]\w+'
+  - '\b\w+Innen\b'
+  - '\b\w+:innen\b'
+  - '\b\w+\(\w+in\)\b'


### PR DESCRIPTION
## Summary
- update Vale style token definitions to use single-quoted scalars
- preserve the intended regular expressions without triggering YAML escape parsing errors

## Testing
- not run (vale not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc03a2b4f0832cb0d8e77d699419bf