### PR TITLE
Log bind and exposure status on startup

### DIFF
--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -23,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     let addr = resolve_bind_addr(expose_config)?;
-    tracing::info!("listening on http://{addr}");
+    tracing::info!(%addr, expose_config, "starting server");
     let listener = TcpListener::bind(addr).await?;
     axum::serve(listener, app).await?;
     Ok(())


### PR DESCRIPTION
## Summary
- log the bind address and expose-config state during startup to highlight loopback defaults

## Testing
- cargo test -p hauski-core

------
https://chatgpt.com/codex/tasks/task_e_68dc1f6cef00832c906177d9def935d6