### PR TITLE
Fix Vale GermanComments scope

### DIFF
--- a/.vale/styles/hauski/GermanComments/GermanComments.yml
+++ b/.vale/styles/hauski/GermanComments/GermanComments.yml
@@ -1,7 +1,7 @@
 extends: existence
 message: "Use English in code comments."
 level: error
-scope: comment
+scope: sentence
 ignorecase: true
 nonword: true
 tokens:


### PR DESCRIPTION
## Summary
- update the Vale GermanComments rule to use the supported `sentence` scope instead of the invalid `comment`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc247e152c832c9f025a60b3817ad7