### PR TITLE
Fix Prometheus counter name for HTTP metrics

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -59,7 +59,7 @@ impl AppState {
 
         let http_requests: Family<HttpLabels, Counter<u64>> = Family::default();
         registry.register(
-            "http_requests",
+            "http_requests_total",
             "Total number of HTTP requests received",
             http_requests.clone(),
         );


### PR DESCRIPTION
## Summary
- rename the HTTP request Prometheus counter to `http_requests_total` to follow naming conventions

## Testing
- cargo build --workspace *(fails: existing raw string in crates/core/src/config.rs is unterminated)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2adb5c0c832c8cc45274bb73d13f