### PR TITLE
Fix raw string literal termination in config test

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -217,7 +217,7 @@ mod tests {
 
         {
             let mut file = File::create(&path).unwrap();
-            writeln!(file, r#"default: deny
+            writeln!(file, r#"default: deny"#).unwrap();
         }
 
         let routing = load_routing(&path).unwrap();


### PR DESCRIPTION
## Summary
- close the raw string literal in `routing_policy_with_explicit_default_and_no_rules`
- ensure the test writes a valid `default: deny` YAML line before parsing routing config

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc2d637fa0832cac486de063d210cd