### PR TITLE
Restore routing configuration wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,12 +325,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -325,6 +354,29 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -338,10 +390,15 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -360,6 +417,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -391,6 +454,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "thiserror",
  "tokio",
  "tower",
@@ -496,7 +560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -884,6 +948,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ prometheus-client = "0.22"
 walkdir = "2"
 dirs = "5"
 # sqlx bewusst nicht vorgezogen, bis erste DB-Crate existiert
+tower-http = { version = "0.5", features = ["cors"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,6 +19,7 @@ serde_yaml.workspace = true
 prometheus-client.workspace = true
 walkdir.workspace = true
 dirs.workspace = true
+tower-http.workspace = true
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -38,6 +38,13 @@ pub struct ModelEntry {
     pub canary: Option<bool>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(transparent)]
+pub struct RoutingPolicy(pub serde_yaml::Value);
+
+pub type RoutingRule = serde_yaml::Value;
+pub type RoutingDecision = serde_yaml::Value;
+
 pub fn load_limits<P: AsRef<Path>>(path: P) -> anyhow::Result<Limits> {
     let content = fs::read_to_string(path)?;
     let limits = serde_yaml::from_str(&content)?;
@@ -48,4 +55,10 @@ pub fn load_models<P: AsRef<Path>>(path: P) -> anyhow::Result<ModelsFile> {
     let content = fs::read_to_string(path)?;
     let models = serde_yaml::from_str(&content)?;
     Ok(models)
+}
+
+pub fn load_routing<P: AsRef<Path>>(path: P) -> anyhow::Result<RoutingPolicy> {
+    let content = fs::read_to_string(path)?;
+    let routing = serde_yaml::from_str(&content)?;
+    Ok(routing)
 }

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -1,4 +1,5 @@
-use hauski_core::{build_app, load_limits, load_models};
+use axum::http::HeaderValue;
+use hauski_core::{build_app, load_limits, load_models, load_routing};
 use std::{env, net::SocketAddr};
 use tokio::net::TcpListener;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -16,10 +17,20 @@ async fn main() -> anyhow::Result<()> {
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
 
+    let routing_path =
+        env::var("HAUSKI_ROUTING").unwrap_or_else(|_| "./policies/routing.yaml".into());
+    let allowed_origin =
+        env::var("HAUSKI_ALLOWED_ORIGIN").unwrap_or_else(|_| "http://127.0.0.1:8080".into());
+    let allowed_origin_header = HeaderValue::from_str(&allowed_origin).map_err(|e| {
+        anyhow::anyhow!("invalid HAUSKI_ALLOWED_ORIGIN '{}': {}", allowed_origin, e)
+    })?;
+
     let app = build_app(
         load_limits(limits_path)?,
         load_models(models_path)?,
+        load_routing(routing_path)?,
         expose_config,
+        allowed_origin_header,
     );
 
     let addr = resolve_bind_addr(expose_config)?;
@@ -43,7 +54,9 @@ fn resolve_bind_addr(expose_config: bool) -> anyhow::Result<SocketAddr> {
         std::net::IpAddr::V6(v6) => v6.is_loopback(),
     };
     if expose_config && !is_loopback {
-        anyhow::bail!("HAUSKI_EXPOSE_CONFIG requires loopback bind; set HAUSKI_BIND=127.0.0.1:<port>");
+        anyhow::bail!(
+            "HAUSKI_EXPOSE_CONFIG requires loopback bind; set HAUSKI_BIND=127.0.0.1:<port>"
+        );
     }
     if !expose_config && !is_loopback {
         tracing::warn!(


### PR DESCRIPTION
## Summary
- re-export routing policy helpers and keep routing state in the app alongside the new CORS layer
- expose `/config/routing` when configuration endpoints are enabled and load routing data in `main`
- align the Prometheus counter name with `http_requests_total` and extend the unit tests accordingly

## Testing
- cargo test -p hauski-core *(fails: unable to reach crates.io index from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1fad6930832cb18c0da6dee73997