### PR TITLE
Add script to apply patches without touching Cargo.lock

### DIFF
--- a/scripts/git-apply-nolock.sh
+++ b/scripts/git-apply-nolock.sh
@@ -17,4 +17,4 @@ cargo update
 # Stage all changes produced by the patch and cargo update.
 git add -u
 
-echo "✅ Patch angewendet (ohne Cargo.lock). Lockfile neu generiert."
+echo "✅ Patch applied (without Cargo.lock). Lockfile regenerated."


### PR DESCRIPTION
## Summary
- add a reusable helper script that applies patches while skipping Cargo.lock
- regenerate Cargo.lock after patch application and stage resulting changes automatically

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dca832a730832c8e6ac73a16ecaa7f