### PR TITLE
Fix CI workflow by providing Rust toolchain input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
         run: vale .
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: stable
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: rustfmt (check)
@@ -89,6 +90,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@v2
 
       - name: Build core (release)
@@ -215,6 +218,8 @@ jobs:
 
       # Toolchains & cache
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@v2
 
       # nextest (faster tests) & optional tools


### PR DESCRIPTION
## Summary
- ensure each dtolnay/rust-toolchain step receives an explicit `toolchain: stable` input so the action can install the requested toolchain

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dcbcda7ab8832cb4e51d5dde1b48dc