### PR TITLE
Fix heavy CI toolchain configuration and resolve clippy findings

### DIFF
--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: stable
           # we switch the toolchain explicitly via rustup in the next step
           components: rustfmt, clippy
       - uses: taiki-e/install-action@v2

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -62,6 +62,7 @@ pub struct Asr {
 // this type to stay resilient even if new fields that lack `Default`
 // derivations are introduced in the future. The explicit construction also
 // makes the intended baseline configuration obvious to readers.
+#[allow(clippy::derivable_impls)]
 impl Default for Limits {
     fn default() -> Self {
         Self {
@@ -215,11 +216,12 @@ mod tests {
             .as_mapping()
             .expect("routing policy should be a mapping");
         let default_key = serde_yaml::Value::String("default".into());
+        let allow_key = serde_yaml::Value::String("allow".into());
         assert_eq!(
             mapping.get(&default_key),
             Some(&serde_yaml::Value::String("deny".into()))
         );
-        assert!(!mapping.contains_key(&serde_yaml::Value::String("allow".into())));
+        assert!(!mapping.contains_key(&allow_key));
         let _ = std::fs::remove_file(path);
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -261,13 +261,13 @@ async fn cors_middleware(
 
     if req.method() == Method::OPTIONS {
         if !origin_allowed {
-            return Ok(Response::builder()
+            return Response::builder()
                 .status(StatusCode::FORBIDDEN)
                 .body(Body::empty())
-                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?);
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR);
         }
 
-        return Ok(Response::builder()
+        return Response::builder()
             .status(StatusCode::NO_CONTENT)
             .header(
                 header::ACCESS_CONTROL_ALLOW_ORIGIN,
@@ -284,7 +284,7 @@ async fn cors_middleware(
             )
             .header(header::VARY, HeaderValue::from_static("Origin"))
             .body(Body::empty())
-            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?);
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     let mut response = next.run(req).await;


### PR DESCRIPTION
## Summary
- add the missing toolchain input for the heavy workflow's Rust toolchain installer
- keep the intentional manual `Limits` default while satisfying clippy and tidy test assertions
- simplify the CORS preflight responses to avoid needless `?` usage

## Testing
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test -p hauski-core

------
https://chatgpt.com/codex/tasks/task_e_68dcc0e92ad8832cb3c77d3928a93a92