### PR TITLE
Allow dynamic HTTP path labels

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -169,7 +169,7 @@ impl EncodeLabelSet for HttpLabels {
         mut encoder: prometheus_client::encoding::LabelSetEncoder<'_>,
     ) -> Result<(), fmt::Error> {
         ("method", self.method.as_str()).encode(encoder.encode_label())?;
-        ("path", &*self.path).encode(encoder.encode_label())?;
+        ("path", self.path.as_ref()).encode(encoder.encode_label())?;
         ("status", self.status.as_str()).encode(encoder.encode_label())?;
         Ok(())
     }


### PR DESCRIPTION
## Summary
- allow HTTP metrics helpers to accept non-static path strings
- store HTTP label paths as `Arc<str>` to support dynamically constructed values without repeated conversion

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68dce577d784832cad10e2b4301b8ce0