### PR TITLE
Refactor k6 summary debug output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,9 +172,13 @@ jobs:
             )
           ' observability/k6/summary.json)
 
+          debug_summary() {
+            jq '{http_req_duration: .metrics."http_req_duration", http_req_failed: .metrics."http_req_failed"}' observability/k6/summary.json
+          }
+
           if [[ -z "$P95_ACTUAL" || "$P95_ACTUAL" == "null" ]]; then
             echo "::error::Unable to extract p95 from k6 summary"
-            jq '{http_req_duration: .metrics."http_req_duration", http_req_failed: .metrics."http_req_failed"}' observability/k6/summary.json
+            debug_summary
             exit 1
           fi
 
@@ -188,7 +192,7 @@ jobs:
 
           if [[ -z "$FAIL_RATE" || "$FAIL_RATE" == "null" ]]; then
             echo "::error::Unable to extract fail rate from k6 summary"
-            jq '{http_req_duration: .metrics."http_req_duration", http_req_failed: .metrics."http_req_failed"}' observability/k6/summary.json
+            debug_summary
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- extract a helper function in the k6 enforcement step for printing relevant metrics when parsing fails
- reuse the helper in both error paths to remove duplicated jq invocations

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dce9e57ba0832c908ab6cbf413cbc4