### PR TITLE
Return router and state from build_app

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -114,7 +114,7 @@ pub struct ModelEntry {
     pub canary: Option<bool>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[serde(transparent)]
 pub struct RoutingPolicy(pub serde_yaml::Value);
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -137,7 +137,7 @@ impl AppState {
         self.observe_http_latency(&labels, started.elapsed().as_secs_f64());
     }
 
-    fn set_ready(&self) {
+    pub fn set_ready(&self) {
         self.0.ready.store(true, Ordering::Release);
     }
 
@@ -266,12 +266,11 @@ pub fn build_app(
             .route("/config/routing", get(get_routing));
     }
 
-    // It is safe to mark the app as ready here because there is no additional
-    // asynchronous initialization required beyond building the router and state.
-    // If future changes introduce async setup, move this to after the server is listening.
-    state.set_ready();
-    app.with_state(state.clone())
-        .layer(from_fn_with_state(allowed_origin.clone(), cors_middleware))
+    let app = app
+        .with_state(state.clone())
+        .layer(from_fn_with_state(allowed_origin.clone(), cors_middleware));
+
+    (app, state)
 }
 
 type CorsState = Arc<HeaderValue>;


### PR DESCRIPTION
## Summary
- update build_app to return both the configured Router and its AppState
- expose AppState::set_ready so the caller can mark readiness
- derive PartialEq for RoutingPolicy to keep configuration tests compiling

## Testing
- cargo test -p hauski-core

------
https://chatgpt.com/codex/tasks/task_e_68dcea18d4c4832c9b8413198d6c6c8c