### PR TITLE
Ensure k6 smoke test exports summary

### DIFF
--- a/observability/k6/health-smoke.js
+++ b/observability/k6/health-smoke.js
@@ -1,5 +1,6 @@
 import http from 'k6/http';
 import { sleep } from 'k6';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.4/index.js';
 
 export const options = {
   vus: 5,
@@ -14,4 +15,11 @@ export const options = {
 export default function () {
   http.get('http://localhost:8080/health');
   sleep(0.05);
+}
+
+export function handleSummary(data) {
+  return {
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+    'observability/k6/summary.json': JSON.stringify(data, null, 2),
+  };
 }


### PR DESCRIPTION
## Summary
- use k6's handleSummary hook to always write the exported summary.json
- include a readable stdout summary to aid debugging when CI fails

## Testing
- not run (not easily runnable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dceceaf83c832c8062de0b9d92a278