### PR TITLE
Restore build_app API while exposing state variant

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -250,6 +250,16 @@ pub fn build_app(
     routing: RoutingPolicy,
     expose_config: bool,
     allowed_origin: HeaderValue,
+) -> Router {
+    build_app_with_state(limits, models, routing, expose_config, allowed_origin).0
+}
+
+pub fn build_app_with_state(
+    limits: Limits,
+    models: ModelsFile,
+    routing: RoutingPolicy,
+    expose_config: bool,
+    allowed_origin: HeaderValue,
 ) -> (Router, AppState) {
     let state = AppState::new(limits, models, routing, expose_config);
     let allowed_origin = Arc::new(allowed_origin);
@@ -360,7 +370,7 @@ mod tests {
             }],
         };
         let routing = RoutingPolicy::default();
-        let (app, state) = build_app(limits, models, routing, expose, origin);
+        let (app, state) = build_app_with_state(limits, models, routing, expose, origin);
         state.set_ready();
         app
     }

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -1,5 +1,5 @@
 use axum::http::HeaderValue;
-use hauski_core::{build_app, load_limits, load_models, load_routing};
+use hauski_core::{build_app_with_state, load_limits, load_models, load_routing};
 use std::{env, net::SocketAddr};
 use tokio::{net::TcpListener, signal};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
         anyhow::anyhow!("invalid HAUSKI_ALLOWED_ORIGIN '{}': {}", allowed_origin, e)
     })?;
 
-    let (app, state) = build_app(
+    let (app, state) = build_app_with_state(
         load_limits(limits_path)?,
         load_models(models_path)?,
         load_routing(routing_path)?,


### PR DESCRIPTION
## Summary
- keep `build_app` returning only a `Router` to preserve the existing public API
- introduce `build_app_with_state` for callers that need both the router and the state
- update the binary and tests to consume the new helper that returns the state

## Testing
- cargo test -p hauski-core


------
https://chatgpt.com/codex/tasks/task_e_68dced029124832cbe484dec3b196056