### PR TITLE
Enforce sparse crates.io index usage

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[registries.crates-io]
+protocol = "sparse"


### PR DESCRIPTION
## Summary
- configure cargo to use the sparse crates.io index protocol to avoid CONNECT tunnel errors during dependency downloads

## Testing
- cargo test --workspace -- --nocapture *(fails: unable to reach crates.io because the registry returns a 403 CONNECT tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7b06fa20832caafd41f260017fb2