### PR TITLE
Refactor router setup to merge config routes

### DIFF
--- a/crates/core/src/egress.rs
+++ b/crates/core/src/egress.rs
@@ -371,10 +371,7 @@ egress:
         let guard = EgressGuard::from_policy(&policy).unwrap();
         let reqwest_client = Client::new();
         let client = AllowlistedClient::new(reqwest_client.clone(), guard);
-        let request = reqwest_client
-            .get("https://evil.example")
-            .build()
-            .unwrap();
+        let request = reqwest_client.get("https://evil.example").build().unwrap();
         let err = client.execute(request).await.unwrap_err();
         match err {
             GuardedRequestError::Guard(GuardError::HostDenied { host }) => {


### PR DESCRIPTION
## Summary
- extract helper functions for the core and configuration HTTP routes
- merge the optional configuration router so merge always receives a Router
- run rustfmt, picking up a small formatting tweak in the egress tests

## Testing
- cargo fmt

------
https://chatgpt.com/codex/tasks/task_e_68dd7beabff0832cb93cd117c5aac652