### PR TITLE
Refactor core router setup

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -311,16 +311,10 @@ pub fn build_app_with_state(
     let state = AppState::new(limits, models, routing, flags, expose_config);
     let allowed_origin = Arc::new(allowed_origin);
 
-    let mut app = Router::new()
-        .route("/health", get(health))
-        .route("/ready", get(ready))
-        .route("/metrics", get(metrics));
+    let mut app = core_routes();
 
     if state.expose_config() {
-        app = app
-            .route("/config/limits", get(get_limits))
-            .route("/config/models", get(get_models))
-            .route("/config/routing", get(get_routing));
+        app = app.merge(config_routes());
     }
 
     if state.safe_mode() {
@@ -334,6 +328,20 @@ pub fn build_app_with_state(
         .with_state(state.clone())
         .layer(from_fn_with_state(allowed_origin.clone(), cors_middleware));
     (app, state)
+}
+
+fn core_routes() -> Router<AppState> {
+    Router::new()
+        .route("/health", get(health))
+        .route("/ready", get(ready))
+        .route("/metrics", get(metrics))
+}
+
+fn config_routes() -> Router<AppState> {
+    Router::new()
+        .route("/config/limits", get(get_limits))
+        .route("/config/models", get(get_models))
+        .route("/config/routing", get(get_routing))
 }
 
 // TODO: Implement plugin routes. This is a placeholder returning an empty router.


### PR DESCRIPTION
## Summary
- extract helpers for the core and configuration routes to simplify router construction
- reuse the helpers when building the application to make later route merges conflict-free

## Testing
- cargo fmt
- cargo check -p hauski-core *(fails: unable to reach crates.io index in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd81529ca8832cbe7929d5463a2a7f