### PR TITLE
Fix router merge types in hauski-core

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -345,12 +345,12 @@ fn config_routes() -> Router<AppState> {
 }
 
 // TODO: Implement plugin routes. This is a placeholder returning an empty router.
-fn plugin_routes() -> Router {
+fn plugin_routes() -> Router<AppState> {
     Router::new()
 }
 
 // TODO: Implement cloud routes. This is a placeholder returning an empty router.
-fn cloud_routes() -> Router {
+fn cloud_routes() -> Router<AppState> {
     Router::new()
 }
 


### PR DESCRIPTION
## Summary
- ensure plugin and cloud route helpers return Router<AppState> so they can be merged

## Testing
- cargo check -p hauski-core *(fails: unable to download crates index due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8cc79260832c899c0b7ff14bb8dc