### PR TITLE
Fix method ownership when recording HTTP metrics

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -141,8 +141,8 @@ impl AppState {
         status: StatusCode,
         started: Instant,
     ) {
-        let counter_labels = HttpLabels::new(method.clone(), path, status);
         let duration_labels = HttpDurationLabels::new(method, path);
+        let counter_labels = HttpLabels::new(method.clone(), path, status);
         let elapsed = started.elapsed().as_secs_f64();
         self.0.http_requests.get_or_create(&counter_labels).inc();
         self.0


### PR DESCRIPTION
## Summary
- update HTTP metric label construction to pass the request method by value
- clone the method for counter labels so it can also be reused for duration labels

## Testing
- cargo check -p hauski-core

------
https://chatgpt.com/codex/tasks/task_e_68dd9ab2f630832c903b28943ac0247b