### PR TITLE
Fix CI workflows to provide required toolchain input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
        github.event.pull_request.draft == false &&
        (needs.changes.outputs.rust == 'true' || contains(join(github.event.pull_request.labels.*.name), 'full-ci')))
     runs-on: ubuntu-latest
+    env:
+      toolchain: stable
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +71,7 @@ jobs:
         run: vale .
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.toolchain }}
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: rustfmt (check)
@@ -86,12 +88,14 @@ jobs:
        github.event.pull_request.draft == false &&
        (needs.changes.outputs.rust == 'true' || needs.changes.outputs.policy_limits == 'true' || contains(join(github.event.pull_request.labels.*.name), 'full-ci')))
     runs-on: ubuntu-latest
+    env:
+      toolchain: stable
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.toolchain }}
       - uses: Swatinem/rust-cache@v2
 
       - name: Build core (release)
@@ -238,6 +242,8 @@ jobs:
       (github.event_name != 'merge_group' &&
        github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    env:
+      toolchain: stable
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
@@ -245,7 +251,7 @@ jobs:
       # Toolchains & cache
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.toolchain }}
       - uses: Swatinem/rust-cache@v2
 
       # nextest (faster tests) & optional tools

--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -53,12 +53,14 @@ jobs:
       fail-fast: false
       matrix:
         toolchain: ${{ fromJSON(format('["{0}"]', join(split(needs.decide.outputs.matrix, ','), '","'))) }}
+    env:
+      toolchain: ${{ matrix.toolchain }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.toolchain }}
           # we switch the toolchain explicitly via rustup in the next step
           components: rustfmt, clippy
       - uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Summary
- set the expected `toolchain` environment variable for the lint, smoke, and test jobs in CI
- ensure the heavy workflow passes the correct toolchain value from its matrix
- wire all `dtolnay/rust-toolchain` steps to consume the provided `toolchain` input

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68dd9c527db0832c9ac0bffc39403333