### PR TITLE
Fix clippy warnings in hauski-core

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -121,16 +121,10 @@ pub struct RoutingPolicy(pub serde_yaml::Value);
 pub type RoutingRule = serde_yaml::Value;
 pub type RoutingDecision = serde_yaml::Value;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields, default)]
 pub struct FeatureFlags {
     pub safe_mode: bool,
-}
-
-impl Default for FeatureFlags {
-    fn default() -> Self {
-        Self { safe_mode: false }
-    }
 }
 
 fn parse_env_bool(value: &str) -> Option<bool> {

--- a/crates/core/src/egress.rs
+++ b/crates/core/src/egress.rs
@@ -114,7 +114,7 @@ impl EgressGuard {
             None => return Ok(Self::allow_all()),
         };
 
-        let Some(egress_value) = mapping.get(&serde_yaml::Value::from(KEY_EGRESS)) else {
+        let Some(egress_value) = mapping.get(serde_yaml::Value::from(KEY_EGRESS)) else {
             return Ok(Self::allow_all());
         };
 
@@ -123,7 +123,7 @@ impl EgressGuard {
             .ok_or(EgressGuardError::InvalidEgressSection)?;
 
         let default_action = egress_map
-            .get(&serde_yaml::Value::from(KEY_DEFAULT))
+            .get(serde_yaml::Value::from(KEY_DEFAULT))
             .and_then(|value| value.as_str())
             .unwrap_or("allow")
             .to_ascii_lowercase();
@@ -135,7 +135,7 @@ impl EgressGuard {
         };
 
         let mut allowed = HashSet::new();
-        if let Some(allow_value) = egress_map.get(&serde_yaml::Value::from(KEY_ALLOW)) {
+        if let Some(allow_value) = egress_map.get(serde_yaml::Value::from(KEY_ALLOW)) {
             let allow_seq = allow_value
                 .as_sequence()
                 .ok_or(EgressGuardError::InvalidAllowList)?;


### PR DESCRIPTION
## Summary
- remove needless borrows when looking up egress policy keys so clippy passes
- derive `Default` for `FeatureFlags` instead of maintaining a manual impl

## Testing
- cargo clippy -p hauski-core --lib

------
https://chatgpt.com/codex/tasks/task_e_68dd9ca60384832cbb9d81768dc96772