### PR TITLE
Fix egress allowlist parsing for host:port entries

### DIFF
--- a/crates/core/src/egress.rs
+++ b/crates/core/src/egress.rs
@@ -38,7 +38,13 @@ fn parse_allow_entry(entry: &str) -> Result<AllowedTarget, AllowEntryError> {
     }
 
     if let Ok(url) = Url::parse(trimmed) {
-        return allowed_target_from_url(&url);
+        if url.host_str().is_some() {
+            return allowed_target_from_url(&url);
+        }
+
+        if trimmed.contains("://") {
+            return Err(AllowEntryError::MissingHost);
+        }
     }
 
     let fallback = format!("http://{trimmed}");


### PR DESCRIPTION
## Summary
- ensure allowlist entries without a scheme fall back to HTTP parsing only when no host is detected
- return a clear error when a schemed URL is missing a host component

## Testing
- cargo test -p hauski-core egress::tests

------
https://chatgpt.com/codex/tasks/task_e_68dd9f18ff10832c965199a9a3648565