### PR TITLE
Handle new k6 percentile keys in CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,8 +171,12 @@ jobs:
             | (
               $metric.percentiles["p(95)"]
               // $metric.percentiles["p95"]
+              // $metric.percentiles["95"]
+              // $metric.percentiles["0.95"]
               // $metric.values["p(95)"]
               // $metric.values["p95"]
+              // $metric.values["95"]
+              // $metric.values["0.95"]
             )
           ' observability/k6/summary.json)
 


### PR DESCRIPTION
## Summary
- broaden the jq extraction for k6 http_req_duration percentiles to handle new "95" and "0.95" keys
- keep the CI budget check working when k6 writes different percentile key names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de5fdecfa8832c80bc1c21cae561bd