### PR TITLE
Set default Rust toolchain for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ concurrency:
 
 env:
   RUSTFLAGS: "-Dwarnings"
+  toolchain: stable
 
 jobs:
   changes:


### PR DESCRIPTION
## Summary
- define a default `toolchain` environment variable for the CI workflow so actions receive a valid value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de6cca6aac832ca7b4860a2ae73642