### PR TITLE
Configure PR permissions for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary
- grant the CI workflow read permissions for repository contents and pull requests to avoid token access errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df8af10d48832c847e15dbba76ba85