### PR TITLE
Refine docs workflow and Python setup guidance

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,14 +3,19 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-insert_final_newline = true
-trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
 
 [*.rs]
 indent_size = 4
 
+[*.{yml,yaml,toml}]
+indent_size = 2
+
 [*.md]
 trim_trailing_whitespace = false
 
+[Makefile]
+indent_style = tab

--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build docs
         run: |
           if [ -f "mkdocs.yml" ]; then
-            uv run mkdocs build --clean
+            uv run mkdocs build --strict --clean
           else
             echo "No mkdocs.yml – skipping."
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,34 @@
+# Build artefacts
 target/
+.venv/
+.uv/
+
+# Python caches
+__pycache__/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.python-version
+
+# Logs and misc
 .env
 .direnv/
 **/*.log
+*.log
+.DS_Store
+.coverage
+coverage.xml
+
+# Project specific
 .wgx/profile.local.yml
 # NICHT .vscode/settings.json ignorieren – projektweite Settings sind beabsichtigt
+
+# MkDocs build output
+site/
+
+# Node (falls vorhanden)
+node_modules/
+
+# Tooling
 observability/k6/summary.json
+.lycheecache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-yaml
+      - id: check-json
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+      - id: detect-private-key
+      - id: no-commit-to-branch
+        args: [--branch, main]
+  - repo: https://github.com/lycheeverse/lychee
+    rev: v0.15.1
+    hooks:
+      - id: lychee
+        files: ^docs/.*\.md$
+        args:
+          - --no-progress
+          - --retry-wait-time=2
+          - --max-redirects=5
+          - --exclude-mail

--- a/README.md
+++ b/README.md
@@ -127,11 +127,18 @@ Beispielabfragen für Dashboards oder die Prometheus-Konsole:
 - Lints: `cargo clippy --all-targets --all-features -- -D warnings` und `cargo deny check`.
 - Tests: `cargo test --workspace -- --nocapture`.
 - **Python-Tooling (optional):**
-  - Setup: `just py-init`
+  - Setup:
+    ```bash
+    uv sync --group dev
+    uv run pre-commit install
+    ```
+  - Init: `just py-init`
   - Lint: `just py-lint`
   - Format: `just py-fmt`
   - Tests: `just py-test`
   - Docs lokal: `just py-docs-serve`
+  - Docs strikt: `just py-docs-build`
+  - Hooks lokal prüfen: `just py-pre-commit`
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,22 @@
+# HausKI
+
+> Lokale KI + Orchestrator auf Pop!_OS – mit schnellem Python-Tooling via `uv`.
+
+## Entwicklung
+
+```bash
+just py-init       # dev-Dependencies installieren
+just py-lint       # ruff lint
+just py-fmt        # ruff format
+just py-docs-serve # Dokumentation lokal
+just py-docs-build # statisches Build (./site)
+```
+
+## Ziele
+- Lokale KI (OSS-Modelle) + Cloud-Tools orchestrieren
+- Integration: Obsidian (Canvas), VS Code/GitHub, Qobuz
+- Reproduzierbare Toolchain (uv, just, CI)
+
+---
+
+_Diese Seite ist ein Platzhalter. Ergänze Inhalte nach Bedarf._

--- a/justfile
+++ b/justfile
@@ -3,26 +3,26 @@ set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
 default: build
 
 fmt:
-    cargo fmt --all
+	cargo fmt --all
 
 lint:
-    cargo clippy --all-targets --all-features -- -D warnings
-    cargo deny check
+	cargo clippy --all-targets --all-features -- -D warnings
+	cargo deny check
 
 build:
-    cargo build --workspace
+	cargo build --workspace
 
 test:
-    cargo test --workspace -- --nocapture
+	cargo test --workspace -- --nocapture
 
 run-core:
-    cargo run -p hauski-core
+	cargo run -p hauski-core
 
 run-core-expose:
-    HAUSKI_EXPOSE_CONFIG=true cargo run -p hauski-core
+	HAUSKI_EXPOSE_CONFIG=true cargo run -p hauski-core
 
 run-cli ARGS='':
-    cargo run -p hauski-cli -- {{ARGS}}
+	cargo run -p hauski-cli -- {{ARGS}}
 
 # Python tooling via uv
 
@@ -37,15 +37,18 @@ py-fmt:
 
 py-test:
 	if [ -d "tests" ]; then
-	    uv run pytest -q
+		uv run pytest -q
 	elif ls tests_*.py >/dev/null 2>&1; then
-	    uv run pytest -q
+		uv run pytest -q
 	else
-	    echo "No Python tests found – skipping."
+		echo "No Python tests found – skipping."
 	fi
 
 py-docs-serve:
 	uv run mkdocs serve -a 0.0.0.0:8000
 
 py-docs-build:
-	uv run mkdocs build --clean
+	uv run mkdocs build --strict --clean
+
+py-pre-commit:
+	uv run pre-commit run --all-files

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,35 @@
+site_name: HausKI
+site_url: https://hauski.github.io/hauski
+repo_url: https://github.com/hauski/hauski
+repo_name: hauski/hauski
+edit_uri: edit/main/docs/
+theme:
+  name: material
+  language: de
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - content.code.annotate
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+nav:
+  - Start: index.md
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - pymdownx.emoji
+plugins:
+  - search
+  - minify:
+      minify_html: true
+  - git-revision-date-localized:
+      enable_creation_date: true
+      type: timeago
+extra:
+  social:
+    - icon: material/github
+      link: https://github.com/hauski/hauski

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dev = [
   "pre-commit>=3.8",
   "mkdocs>=1.6",
   "mkdocs-material>=9.5",
+  "mkdocs-minify-plugin>=0.8",
+  "mkdocs-git-revision-date-localized-plugin>=1.3",
   "pytest>=8.3",
   "rich>=13.9"
 ]
@@ -22,3 +24,21 @@ dev = [
 lint = "ruff check ."
 fmt = "ruff format ."
 test = "pytest -q"
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "A", "C4", "ISC", "RET", "SIM", "RUF"]
+ignore = ["E203"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+docstring-code-format = true
+
+[tool.ruff.lint.isort]
+known-first-party = ["hauski"]
+combine-as-imports = true
+split-on-trailing-comma = true


### PR DESCRIPTION
## Summary
- add strict MkDocs build enforcement to the tooling workflow and publish-ready links in the docs config
- document uv-based setup steps for Python tooling and normalize Justfile tab-indentation

## Testing
- uv run mkdocs build --strict --clean *(fails: unable to reach pypi.org from container)*

------
https://chatgpt.com/codex/tasks/task_e_68df8b2a75d4832cb8d3f55714144c18