### PR TITLE
Fix markdown lint for python tools README

### DIFF
--- a/tools/py/README.md
+++ b/tools/py/README.md
@@ -1,0 +1,9 @@
+# Weltgewebe – Python Tools
+
+## Schnellstart
+
+```bash
+cd tools/py
+uv sync        # erstellt venv, installiert deps (aktuell leer)
+uv run python -V
+```


### PR DESCRIPTION
## Summary
- add the missing blank lines around the "Schnellstart" heading and code block in `tools/py/README.md`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfa329f104832c936987214de059f4