### PR TITLE
Format semantah scripts for lint compliance

### DIFF
--- a/tools/semantah/build_graph.py
+++ b/tools/semantah/build_graph.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Stub zum Erzeugen eines semantAH-Graphen."""
+
 from __future__ import annotations
 
 import argparse
@@ -15,7 +16,9 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="semantAH Graph-Stub")
     parser.add_argument(
         "--index-path",
-        default=os.environ.get("HAUSKI_INDEX_PATH", os.path.expandvars("$HOME/.local/state/hauski/index")),
+        default=os.environ.get(
+            "HAUSKI_INDEX_PATH", os.path.expandvars("$HOME/.local/state/hauski/index")
+        ),
         help="Basisverzeichnis für den Index",
     )
     parser.add_argument("--namespace", default=DEFAULT_NAMESPACE, help="Namespace")
@@ -78,7 +81,9 @@ def write_graph(gewebe: Path, namespace: str) -> None:
 
     report = gewebe / "reports"
     report.mkdir(exist_ok=True)
-    (report / "graph_report.md").write_text("# semantAH Graph Report (Stub)\n", encoding="utf-8")
+    (report / "graph_report.md").write_text(
+        "# semantAH Graph Report (Stub)\n", encoding="utf-8"
+    )
 
 
 def main() -> None:

--- a/tools/semantah/build_index.py
+++ b/tools/semantah/build_index.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Stub zum Erzeugen von semantAH-Indexartefakten."""
+
 from __future__ import annotations
 
 import argparse
@@ -15,11 +16,19 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="semantAH Index-Stub")
     parser.add_argument(
         "--index-path",
-        default=os.environ.get("HAUSKI_INDEX_PATH", os.path.expandvars("$HOME/.local/state/hauski/index")),
+        default=os.environ.get(
+            "HAUSKI_INDEX_PATH", os.path.expandvars("$HOME/.local/state/hauski/index")
+        ),
         help="Basisverzeichnis für den Index",
     )
-    parser.add_argument("--namespace", default=DEFAULT_NAMESPACE, help="Namespace (z. B. default oder obsidian)")
-    parser.add_argument("--chunks", nargs="*", help="Optional: Pfade zu Markdown- oder Canvas-Dateien")
+    parser.add_argument(
+        "--namespace",
+        default=DEFAULT_NAMESPACE,
+        help="Namespace (z. B. default oder obsidian)",
+    )
+    parser.add_argument(
+        "--chunks", nargs="*", help="Optional: Pfade zu Markdown- oder Canvas-Dateien"
+    )
     return parser.parse_args()
 
 
@@ -46,7 +55,9 @@ def write_embeddings(gewebe: Path, chunks: List[Path]) -> None:
         )
 
     parquet.write_text("placeholder for embeddings parquet\n", encoding="utf-8")
-    manifest.write_text(json.dumps(manifest_data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    manifest.write_text(
+        json.dumps(manifest_data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
 
 
 def write_report(gewebe: Path, chunks: List[Path]) -> None:

--- a/tools/semantah/update_related.py
+++ b/tools/semantah/update_related.py
@@ -5,6 +5,7 @@ Der Writer ersetzt den Block `<!-- related:auto:start --> … <!-- related:auto:
 idempotent. Er nutzt die stubhaften Graph-Artefakte und erzeugt deterministische
 Ausgaben. Mit `--check` wird nur ein Diff erzeugt.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -19,7 +20,9 @@ from typing import Dict, Iterable, List, Tuple
 DEFAULT_NAMESPACE = "default"
 MARKER_START = "<!-- related:auto:start -->"
 MARKER_END = "<!-- related:auto:end -->"
-BLOCK_PATTERN = re.compile(r"<!-- related:auto:start -->.*?<!-- related:auto:end -->", re.DOTALL)
+BLOCK_PATTERN = re.compile(
+    r"<!-- related:auto:start -->.*?<!-- related:auto:end -->", re.DOTALL
+)
 
 
 @dataclass
@@ -46,7 +49,9 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="semantAH Related Writer")
     parser.add_argument(
         "--index-path",
-        default=os.environ.get("HAUSKI_INDEX_PATH", os.path.expandvars("$HOME/.local/state/hauski/index")),
+        default=os.environ.get(
+            "HAUSKI_INDEX_PATH", os.path.expandvars("$HOME/.local/state/hauski/index")
+        ),
         help="Basisverzeichnis für den Index",
     )
     parser.add_argument("--namespace", default=DEFAULT_NAMESPACE, help="Namespace")
@@ -55,8 +60,14 @@ def parse_args() -> argparse.Namespace:
         default=os.environ.get("HAUSKI_OBSIDIAN_VAULT", "seeds/obsidian.sample"),
         help="Pfad zum Obsidian-Vault",
     )
-    parser.add_argument("--note", help="Nur eine spezifische Note aktualisieren (relativer Pfad)")
-    parser.add_argument("--check", action="store_true", help="Nur Diff anzeigen, keine Dateien schreiben")
+    parser.add_argument(
+        "--note", help="Nur eine spezifische Note aktualisieren (relativer Pfad)"
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Nur Diff anzeigen, keine Dateien schreiben",
+    )
     return parser.parse_args()
 
 
@@ -101,7 +112,9 @@ def load_edges(path: Path) -> List[Edge]:
     return edges
 
 
-def build_related_map(nodes: Dict[str, Node], edges: Iterable[Edge]) -> Dict[str, RelatedBlock]:
+def build_related_map(
+    nodes: Dict[str, Node], edges: Iterable[Edge]
+) -> Dict[str, RelatedBlock]:
     related: Dict[str, RelatedBlock] = {}
 
     for edge in edges:
@@ -157,7 +170,12 @@ def upsert_block(content: str, rendered: str) -> Tuple[str, bool]:
     return new_content, True
 
 
-def update_notes(vault: Path, related_map: Dict[str, RelatedBlock], check_only: bool, single_note: str | None) -> None:
+def update_notes(
+    vault: Path,
+    related_map: Dict[str, RelatedBlock],
+    check_only: bool,
+    single_note: str | None,
+) -> None:
     for relative_path, block in sorted(related_map.items()):
         if single_note and relative_path != single_note:
             continue


### PR DESCRIPTION
## Summary
- apply Ruff formatting to the semantah build and update scripts
- wrap long argument declarations and imports to meet style checks

## Testing
- uv run ruff check .
- uv run ruff format --check .

------
https://chatgpt.com/codex/tasks/task_e_68dfa33bcf50832caabb966b6fc64ee5