### PR TITLE
Fix broken documentation references for strict CI

### DIFF
--- a/docs/adr/ADR-0001__ziele-und-scope.md
+++ b/docs/adr/ADR-0001__ziele-und-scope.md
@@ -5,7 +5,7 @@
 
 ## Kontext
 
-Die HausKI soll als integriertes System für Smart-Home-Assistenten entstehen. Das Zielbild wird in der [HausKI-Skizze](../../hauski-skizze.md) beschrieben und dient als Grundlage für Architektur- und Produktentscheidungen.
+Die HausKI soll als integriertes System für Smart-Home-Assistenten entstehen. Das Zielbild wird in der HausKI-Skizze (Datei fehlt derzeit) beschrieben und dient als Grundlage für Architektur- und Produktentscheidungen.
 
 ## Entscheidung
 

--- a/docs/process/sprache.md
+++ b/docs/process/sprache.md
@@ -25,7 +25,7 @@ Diese Richtlinie beschreibt Tonalität, Wortwahl und Formatkonventionen für das
 
 ## Durchsetzung & Tools
 
-Vale prüft sowohl Prosa als auch Kommentare. Die Konfiguration liegt in [.vale.ini](../../.vale.ini).
+Vale prüft sowohl Prosa als auch Kommentare. Die Konfiguration liegt in einer lokalen `.vale.ini` (Datei fehlt derzeit).
 
 - `vale .` lokal ausführen oder den entsprechenden CI-Schritt abwarten.
 - Markdown-Dateien unterliegen dem Style `hauski/GermanProse` (Deutsch erlaubt, Gender-Sonderzeichen verboten).


### PR DESCRIPTION
## Summary
- remove the strict-mode link to the missing HausKI sketch document from ADR-0001
- replace the broken reference to the Vale configuration in the language guideline with an explanatory note

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfa695fa88832c91e8e889f36ec60a