### PR TITLE
Fix GitHub problem matcher severity values

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -6,7 +6,7 @@
         {
           "regexp": "^(error)(\\[[^\\]]+\\])?:\\s+(.*)$",
           "message": 3,
-          "severity": "error"
+          "severity": 1
         },
         {
           "regexp": "^\\s*-->\\s+([^:]+):(\\d+):(\\d+)$",
@@ -26,7 +26,7 @@
         {
           "regexp": "^(warning)(\\[[^\\]]+\\])?:\\s+(.*)$",
           "message": 3,
-          "severity": "warning"
+          "severity": 2
         },
         {
           "regexp": "^\\s*-->\\s+([^:]+):(\\d+):(\\d+)$",


### PR DESCRIPTION
## Summary
- update the rust problem matcher to use numeric severity values expected by GitHub Actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfff1266d0832cab12b41c7a81e7c5