### PR TITLE
Bring axum::FromRef into scope in core

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,12 +1,13 @@
 use axum::{
     body::Body,
-    extract::{FromRef, State},
+    extract::State,
     http::{header, HeaderValue, Method, Request, StatusCode},
     middleware::{from_fn_with_state, Next},
     response::{IntoResponse, Response},
     routing::get,
     Json, Router,
 };
+use axum::extract::FromRef;
 use hauski_indexd::{router as index_router, IndexState};
 use prometheus_client::{
     encoding::{text::encode, EncodeLabel, EncodeLabelSet},


### PR DESCRIPTION
## Summary
- import `axum::extract::FromRef` so the `IndexState` implementation is available when building the router

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfffbbd93c832c90a3630ca8b1bf56