### PR TITLE
Tighten uv workflows

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -36,7 +36,7 @@ jobs:
             ${{ runner.os }}-uv-
 
       - name: Sync dev deps
-        run: uv sync --group dev
+        run: uv sync --group dev --frozen
 
       - name: Ruff check
         run: uv run ruff check .

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Beispielabfragen für Dashboards oder die Prometheus-Konsole:
 - **Python-Tooling (optional):**
   - Setup:
     ```bash
-    uv sync --group dev
+    uv sync --group dev --frozen
     uv run pre-commit install
     ```
   - Init: `just py-init`

--- a/justfile
+++ b/justfile
@@ -27,7 +27,7 @@ run-cli ARGS='':
 # Python tooling via uv
 
 py-init:
-	uv sync --group dev
+        uv sync --group dev --frozen
 
 py-lint:
 	uv run ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ readme = "README.md"
 
 [tool.uv]
 managed = true
+python-preference = "managed"
+python-version = "3.10"
 
 [dependency-groups]
 dev = [
@@ -18,6 +20,18 @@ dev = [
   "mkdocs-git-revision-date-localized-plugin>=1.3",
   "pytest>=8.3",
   "rich>=13.9"
+]
+
+[project.optional-dependencies]
+dev = [
+  "ruff>=0.6",
+  "pre-commit>=3.8",
+  "mkdocs>=1.6",
+  "mkdocs-material>=9.5",
+  "mkdocs-minify-plugin>=0.8",
+  "mkdocs-git-revision-date-localized-plugin>=1.3",
+  "pytest>=8.3",
+  "rich>=13.9",
 ]
 
 [scripts]

--- a/tools/py/README.md
+++ b/tools/py/README.md
@@ -4,6 +4,6 @@
 
 ```bash
 cd tools/py
-uv sync        # erstellt venv, installiert deps (aktuell leer)
+uv sync --frozen        # erstellt venv, installiert deps (aktuell leer)
 uv run python -V
 ```


### PR DESCRIPTION
## Summary
- enforce locked dependency resolution for uv sync in CI, just recipes, and docs
- pin the managed Python channel for uv and mirror dev dependencies for pip-based installs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e000d9bb2c832caa8d23f41cf6fd75