### PR TITLE
Add missing checksum file for vendored signal-hook-registry

### DIFF
--- a/vendor/signal-hook-registry/.cargo-checksum.json
+++ b/vendor/signal-hook-registry/.cargo-checksum.json
@@ -1,0 +1,1 @@
+{"files":{"Cargo.toml":"f00842a7eddaf3d705d80e2018ba3711832c89c59fed4d840d7eb144d3e565a4","src/lib.rs":"cd1a5ba4321ae4aa515932805014c18e847f20af36b4a0fdfe032b4b5e5ca60a"},"package":null}


### PR DESCRIPTION
## Summary
- add the missing `.cargo-checksum.json` for the vendored `signal-hook-registry` crate so Cargo can validate the local copy

## Testing
- cargo metadata --format-version=1 *(fails in this environment because the vendor directory only contains the patched crate and other crates must be downloaded from crates.io, which is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68e200295744832c9075314486a36196