### PR TITLE
Fix deny config unmaintained advisory level

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,7 @@ targets = [{ triple = "x86_64-unknown-linux-gnu" }]
 
 [advisories]
 vulnerability = "deny"
-unmaintained = "warn"
+unmaintained = "deny"
 yanked = "warn"
 notice = "warn"
 ignore = []


### PR DESCRIPTION
## Summary
- set the unmaintained advisory level in deny.toml to a supported value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2729d3638832c9a8eb9a44ebc0b6e