### PR TITLE
Simplify cargo-deny installation in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -68,8 +68,10 @@ jobs:
               tar -xzf cargo-deny.tar.gz -C "$tmpdir"
               binpath="$(find "$tmpdir" -type f -name 'cargo-deny' -perm -111 | head -n1 || true)"
               if [[ -n "${binpath:-}" ]]; then
-                sudo install -m 0755 "$binpath" /usr/local/bin/cargo-deny
-                echo "Installed prebuilt cargo-deny to /usr/local/bin."
+                mkdir -p "$HOME/.cargo/bin"
+                install -m 0755 "$binpath" "$HOME/.cargo/bin/cargo-deny"
+                echo "Installed prebuilt cargo-deny to $HOME/.cargo/bin."
+                export PATH="$HOME/.cargo/bin:$PATH"
               else
                 echo "Prebuilt archive did not contain cargo-deny binary; falling back to cargo install."
                 cargo install cargo-deny --locked --force


### PR DESCRIPTION
## Summary
- replace the duplicated cargo-deny setup with a single bash helper that prefers prebuilt archives and falls back to cargo install
- add trap-based cleanup to avoid rm -rf on unset directories and allow optional version pinning via CARGO_DENY_VERSION
- simplify the cargo deny invocation into one combined check command

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e27480ca5c832c8ed5731540cbe442