### PR TITLE
Fix rust problem matcher loop message requirement

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -17,8 +17,9 @@
         },
         { "regexp": "^\\s*\\|$" },
         {
-          "regexp": "^\\s*[|].*$",
-          "loop": true
+          "regexp": "^\\s*[|]\\s*(.*)$",
+          "loop": true,
+          "message": 1
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add a capture group for the continuation lines in the rust problem matcher
- provide the required message field for the looped pattern

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e29c7b1124832ca1d4786709ebebfa