### PR TITLE
Fix rust problem matcher message duplication

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -18,8 +18,7 @@
         { "regexp": "^\\s*\\|$" },
         {
           "regexp": "^\\s*[|]\\s*(.*)$",
-          "loop": true,
-          "message": 1
+          "loop": true
         }
       ]
     }


### PR DESCRIPTION
## Summary
- remove the duplicate `message` property from the custom rustc problem matcher so GitHub Actions can register it successfully

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2b090e6dc832c8774e9d19fa60972