### PR TITLE
Fix rust problem matcher message

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -18,7 +18,8 @@
         { "regexp": "^\\s*\\|$" },
         {
           "regexp": "^\\s*[|]\\s*(.*)$",
-          "loop": true
+          "loop": true,
+          "message": "$1"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add the missing message field to the GitHub Actions rust problem matcher loop pattern

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e3b5799860832ca5e580d80c5332e7