### PR TITLE
Ensure coverage workflow prepares vendor snapshot

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+      - name: Ensure vendor snapshot
+        run: bash scripts/ensure-vendor.sh
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh
       - name: Cache cargo + target


### PR DESCRIPTION
## Summary
- run the ensure-vendor helper in the coverage workflow so offline builds have dependencies prepared before verification

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3b580ae60832c8b51e875558772fe