### PR TITLE
Ensure uv 3.10 in CI tools workflow

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -26,6 +26,11 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
+      - name: Update uv to required version
+        run: |
+          uv self update 3.10
+          uv --version
+
       - name: Cache uv
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- update the CI tools workflow to explicitly upgrade uv to version 3.10 after installation
- record the uv version to aid debugging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c9777944832c88a0e16050bea867