### PR TITLE
Fix shellcheck SC2030/SC2031 in ensure-vendor script

### DIFF
--- a/scripts/ensure-vendor.sh
+++ b/scripts/ensure-vendor.sh
@@ -16,10 +16,7 @@ mkdir -p vendor
 GEN_LOCK_LOG="$(mktemp /tmp/cargo-generate-lockfile.XXXXXX.log)"
 trap 'rm -f "${GEN_LOCK_LOG}" "${LOGFILE:-}"' EXIT
 
-if ! (
-  export CARGO_NO_LOCAL_CONFIG=1
-  cargo generate-lockfile > "${GEN_LOCK_LOG}" 2>&1
-); then
+if ! CARGO_NO_LOCAL_CONFIG=1 cargo generate-lockfile > "${GEN_LOCK_LOG}" 2>&1; then
   cat "${GEN_LOCK_LOG}" >&2
   echo "Failed to refresh Cargo.lock via cargo generate-lockfile." >&2
   echo "Bitte aktualisiere die Lock-Datei manuell und versuche es erneut." >&2
@@ -28,10 +25,7 @@ fi
 
 LOGFILE="$(mktemp /tmp/cargo-vendor.XXXXXX.log)"
 
-if ! (
-  export CARGO_NO_LOCAL_CONFIG=1
-  cargo vendor --locked > "${LOGFILE}" 2>&1
-); then
+if ! CARGO_NO_LOCAL_CONFIG=1 cargo vendor --locked > "${LOGFILE}" 2>&1; then
   cat "${LOGFILE}" >&2
   echo "Failed to regenerate vendor snapshot." >&2
   exit 1


### PR DESCRIPTION
## Summary
- replace subshells in `scripts/ensure-vendor.sh` with single-command invocations
- ensure environment variable changes happen in the main shell to avoid SC2030/SC2031

## Testing
- not run (shellcheck is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e3cde9fc88832ca4f7963aa900f045