### PR TITLE
Align workflows and metadata with heimgewebe org

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
+  id-token: write
   contents: read
   pull-requests: read
 

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -4,6 +4,7 @@ on:
     branches: [ "main" ]
     types: [opened, synchronize, reopened, ready_for_review]
 permissions:
+  id-token: write
   contents: read
   pull-requests: write
 concurrency:

--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -6,7 +6,9 @@ on:
     types: [labeled, synchronize, reopened, ready_for_review]
     branches: [ main ]
 
-permissions: { contents: read }
+permissions:
+  id-token: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,6 +18,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  id-token: write
   contents: read
 
 concurrency:

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -8,6 +8,7 @@ on:
       - .github/workflows/vendor.yml
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,2 @@
-https://github.com/hauski/hauski/actions/workflows/coverage.yml?query=branch%3Amain
-https://github.com/hauski/hauski/actions/workflows/security.yml?query=branch%3Amain
+https://github.com/heimgewebe/hausKI/actions/workflows/coverage.yml?query=branch%3Amain
+https://github.com/heimgewebe/hausKI/actions/workflows/security.yml?query=branch%3Amain

--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -76,7 +76,7 @@ tasks:
         [ -f pyproject.toml ] && grep -q '^\[project\]\s*$' pyproject.toml || true
 
 meta:
-  owner: "alexdermohr"
+  owner: "heimgewebe"
   conventions:
     gewebedir: ".gewebe"
     version_endpoint: "/version"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: HausKI
-site_url: https://hauski.github.io/hauski
-repo_url: https://github.com/hauski/hauski
-repo_name: hauski/hauski
+site_url: https://heimgewebe.github.io/hausKI
+repo_url: https://github.com/heimgewebe/hausKI
+repo_name: heimgewebe/hausKI
 edit_uri: edit/main/docs/
 theme:
   name: material
@@ -32,4 +32,4 @@ plugins:
 extra:
   social:
     - icon: material/github
-      link: https://github.com/hauski/hauski
+      link: https://github.com/heimgewebe/hausKI


### PR DESCRIPTION
## Summary
- allow GitHub Actions workflows to request OIDC ID tokens for the heimgewebe org setup
- update lychee ignore list and WGX profile owner to reference heimgewebe/hausKI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4cb335ea8832cb069e9fc4bbf140c