### PR TITLE
Fix duplicate message keys in rust problem matcher

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -13,17 +13,14 @@
           "regexp": "^\\s*-->\\s+([^:]+):(\\d+):(\\d+)$",
           "file": 1,
           "line": 2,
-          "column": 3,
-          "message": 0
+          "column": 3
         },
         {
-          "regexp": "^(\\s*\\|)$",
-          "message": 1
+          "regexp": "^(\\s*\\|)$"
         },
         {
           "regexp": "^\\s*\\|\\s*(.*)$",
-          "loop": true,
-          "message": 1
+          "loop": true
         }
       ]
     }


### PR DESCRIPTION
## Summary
- remove redundant `message` assignments from the Rust problem matcher to avoid conflicts in GitHub Actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4cf4d3d04832cbead2a190804e8a4