### PR TITLE
Fix uv version in CI tools workflow

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -26,9 +26,9 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
-      - name: Update uv to required version
+      - name: Ensure uv version
         run: |
-          uv self update 3.10
+          uv self update v0.1.18
           uv --version
 
       - name: Cache uv


### PR DESCRIPTION
## Summary
- update the CI tools workflow to request uv version v0.1.18 instead of the invalid 3.10 release
- keep the existing installation flow while ensuring the requested version is valid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4d0f1b758832cb79fb0a2bf673b41