### PR TITLE
Ensure uv version in wgx guard

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -62,6 +62,8 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          uv self update 3.10
           uv --version
           uv sync --frozen
 


### PR DESCRIPTION
## Summary
- ensure the wgx-guard workflow updates uv to version 3.10 when bootstrapping
- add the cargo bin directory to the PATH to make the installed uv available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4d17c6cbc832c8731ae6eea09aa5f