### PR TITLE
chore: make vendor checks optional when falling back to crates.io

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,10 @@
 [registries.crates-io]
 protocol = "sparse"
 
-[source.crates-io]
-replace-with = "vendored-sources"
-
+# Offline builds can opt into the vendored snapshot by passing
+# `--config source.crates-io.replace-with=vendored-sources` or by setting
+# `CARGO_CONFIG` to include this file together with an override.  We keep the
+# directory definition here so `cargo vendor` continues to materialise crates
+# under `vendor/` without requiring additional configuration.
 [source.vendored-sources]
 directory = "vendor"

--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ cargo test --workspace -- --nocapture
 
 > 💡 **Hinweis auf Offline-Builds:** Bevor du `cargo clippy`, `cargo build` oder
 > `cargo test` ausführst, stelle sicher, dass `vendor/` alle benötigten Crates
-> enthält. Der neue Helper `scripts/check-vendor.sh` bricht früh mit einer
-> verständlichen Meldung ab, falls beispielsweise `axum` noch nicht lokal
-> vorliegt. Dank `.cargo/config.toml` nutzt Cargo automatisch die lokal
-> eingecheckte Vendor-Struktur.
+> enthält. Der Helper `scripts/check-vendor.sh` warnt früh mit einer
+> verständlichen Meldung, falls beispielsweise `axum` noch nicht lokal
+> vorliegt. Standardmäßig lädt Cargo fehlende Crates wieder aus `crates.io`;
+> setze `HAUSKI_ENFORCE_VENDOR=1`, wenn der Build zwingend offline erfolgen
+> soll.
 
 > Falls CI mit der Meldung `the lock file … needs to be updated but --locked was
 > passed` oder `no matching package named 'axum' found` stoppt, führe die
@@ -68,16 +69,16 @@ cargo test --workspace -- --nocapture
 
 ```toml
 # .cargo/config.toml
-[source.crates-io]
-replace-with = "vendored-sources"
+[registries.crates-io]
+protocol = "sparse"
 
 [source.vendored-sources]
 directory = "vendor"
 ```
 
-> Falls du eine eigene Konfiguration in einem Fork verwendest, behalte die
-> `replace-with`-Direktive unbedingt bei, damit Builds auf air-gapped Hosts
-> zuverlässig funktionieren.
+> Offline-Builds kannst du erzwingen, indem du Cargo mit `--config` oder einer
+> eigenen `config.toml` startest, die `source.crates-io.replace-with =
+> "vendored-sources"` setzt. So bleiben air-gapped Workflows weiterhin möglich.
 
 **Vendor-Snapshot befüllen**
 

--- a/scripts/check-vendor.sh
+++ b/scripts/check-vendor.sh
@@ -26,7 +26,8 @@ fi
 missing_display=$(printf '%s ' "${missing[@]}")
 missing_display=${missing_display% }
 
-cat <<MSG
+if [[ ${HAUSKI_ENFORCE_VENDOR:-0} != "0" ]]; then
+  cat <<MSG
 error: vendored crates missing: ${missing_display}
 
 Der Workspace erzwingt Offline-Builds über '.cargo/config.toml'. Wenn Cargo
@@ -41,4 +42,12 @@ mit:
 
 Sobald 'vendor/' vollständig ist, erneut ausführen.
 MSG
-exit 1
+  exit 1
+fi
+
+cat <<MSG
+warning: vendored crates missing: ${missing_display}
+
+Cargo fällt nun auf crates.io zurück. Setze HAUSKI_ENFORCE_VENDOR=1, wenn der
+Build zwingend offline erfolgen muss.
+MSG


### PR DESCRIPTION
## Summary
- stop forcing the crates.io replacement in `.cargo/config.toml` so builds can fall back to the public registry when the vendor tree is incomplete
- allow `scripts/check-vendor.sh` to warn by default and fail only when `HAUSKI_ENFORCE_VENDOR=1`
- document the new fallback behaviour in the README so developers know how to opt into offline-only builds

## Testing
- `bash scripts/check-vendor.sh`
- `HAUSKI_ENFORCE_VENDOR=1 bash scripts/check-vendor.sh`

------
https://chatgpt.com/codex/tasks/task_e_68e4d1397dfc832c8beae06b8b78df62