### PR TITLE
Ensure wgx guard workflow pins uv 3.10

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+          uv self update 3.10
           uv --version
           uv sync --frozen
 


### PR DESCRIPTION
## Summary
- update the wgx-guard workflow to upgrade uv to version 3.10 before running commands

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4d1547f94832ca8dd3c01f46884d6