### PR TITLE
Update uv version in CI workflow

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Ensure uv version
         run: |
-          uv self update v0.1.18
+          uv self update v0.1.17
           uv --version
 
       - name: Cache uv


### PR DESCRIPTION
## Summary
- update the CI tools workflow to pin uv to version v0.1.17 so setup succeeds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4d49a0a20832c8f84cbb908931021