### PR TITLE
Remove duplicate message field from rust problem matcher

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -13,8 +13,7 @@
           "regexp": "^\\s*-->\\s+([^:]+):(\\d+):(\\d+)$",
           "file": 1,
           "line": 2,
-          "column": 3,
-          "message": 0
+          "column": 3
         },
         {
           "regexp": "^(\\s*\\|)$",


### PR DESCRIPTION
## Summary
- remove the duplicate message property from the second rustc pattern to comply with problem matcher schema

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4d184b804832ca278c00c75e6950b