### PR TITLE
Fix rust problem matcher message duplication

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -4,10 +4,10 @@
       "owner": "rustc",
       "pattern": [
         {
-          "regexp": "^(error|warning|note|help)(\\[(E\\d{4}|[\\w\\-]+)\\])?:\\s+(.*)$",
+          "regexp": "^(error|warning|note|help)(?:\\[(E\\d{4}|[\\w\\-]+)\\])?:\\s+(.*)$",
           "severity": 1,
-          "code": 3,
-          "message": 4
+          "code": 2,
+          "message": 3
         },
         {
           "regexp": "^\\s*-->\\s+([^:]+):(\\d+):(\\d+)$",


### PR DESCRIPTION
## Summary
- update the rust problem matcher regex to avoid duplicate capture groups for the diagnostic message
- adjust the code and message capture indices after simplifying the optional code bracket expression

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4d49421e0832ca603da2bb2fae886