### PR TITLE
Fix rust matcher messages

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -16,11 +16,13 @@
           "column": 3
         },
         {
-          "regexp": "^(\\s*\\|)$"
+          "regexp": "^(\\s*\\|)$",
+          "message": 1
         },
         {
           "regexp": "^\\s*\\|\\s*(.*)$",
-          "loop": true
+          "loop": true,
+          "message": 1
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add missing message fields to the GitHub Actions rust matcher patterns

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4d6ca4068832cb1d1ad512f15e18b