### PR TITLE
Fix router state type instantiation in indexd

### DIFF
--- a/crates/indexd/src/lib.rs
+++ b/crates/indexd/src/lib.rs
@@ -109,7 +109,7 @@ where
     S: Clone + Send + Sync + 'static,
     IndexState: FromRef<S>,
 {
-    Router::new()
+    Router::<S>::new()
         .route("/upsert", post(upsert_handler))
         .route("/search", post(search_handler))
 }


### PR DESCRIPTION
## Summary
- ensure the indexd router is constructed with the caller-provided state type

## Testing
- cargo check *(fails: network access to crates.io is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e55ab49f78832c90e929bf7142083f