### PR TITLE
Fix rust problem matcher duplicate message property

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -20,8 +20,7 @@
         },
         {
           "regexp": "^\\s*\\|\\s*(.*)$",
-          "loop": true,
-          "message": 1
+          "loop": true
         }
       ]
     }


### PR DESCRIPTION
## Summary
- remove the duplicate `message` property from the final pattern in `.github/rust.json`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e72f8fc91c832cae19e168a02f8662