### PR TITLE
Fix cargo-deny unmaintained configuration value

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,7 @@ targets = [{ triple = "x86_64-unknown-linux-gnu" }]
 
 [advisories]
 vulnerability = "deny"
-unmaintained = "warn"
+unmaintained = "deny"
 yanked = "warn"
 notice = "warn"
 ignore = []


### PR DESCRIPTION
## Summary
- update the cargo-deny advisory level for unmaintained crates to use the supported value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e72f939ab0832cba1d6fa5b903cf26