### PR TITLE
Fix rust problem matcher loop message

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -20,7 +20,8 @@
         },
         {
           "regexp": "^\\s*\\|\\s*(.*)$",
-          "loop": true
+          "loop": true,
+          "message": 1
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add the missing message property to the loop pattern in the rust problem matcher

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8c8f15ed4832c8674931c22e8fb49