### PR TITLE
Enable Rust problem matcher in codex review workflow

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -16,6 +16,8 @@ jobs:
     if: ${{ github.event.pull_request.draft == false }}
     steps:
       - uses: actions/checkout@v4
+      - name: Enable Rust problem matchers
+        run: echo "::add-matcher::.github/rust.json"
       - name: Quick checks
         run: |
           set -e


### PR DESCRIPTION
## Summary
- add an explicit step to register the repository's Rust problem matcher in the codex-review workflow so compiler diagnostics are surfaced during quick checks

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e8eb1d5bd0832cad43a93f4f33dfc4