### PR TITLE
Fix rust problem matcher duplicate message

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -20,8 +20,7 @@
         },
         {
           "regexp": "^\\s*\\|\\s*(.*)$",
-          "loop": true,
-          "message": 1
+          "loop": true
         }
       ]
     }


### PR DESCRIPTION
## Summary
- remove duplicate message property from looping pattern in rust problem matcher
- ensure problem matcher matches GitHub specification to avoid job log warnings

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e8f3dd7c0c832ca87becfe9b2e8221