### PR TITLE
Fix rust problem matcher loop message field

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -20,7 +20,8 @@
         },
         {
           "regexp": "^\\s*\\|\\s*(.*)$",
-          "loop": true
+          "loop": true,
+          "message": 1
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add the missing message capture to the looped pattern in the Rust problem matcher so GitHub Actions accepts it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ea4c608de8832c85e976b46a282a3b