### PR TITLE
Set minimal permissions for contracts workflow

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,7 +1,16 @@
-name: contracts-validate
+name: contracts
+
 on: [push, pull_request]
+
+#
+# Explizite, minimale Rechte für GITHUB_TOKEN.
+# Verhindert die CodeQL-Warnung und begrenzt das Risiko.
+#
 permissions:
   contents: read
+
 jobs:
   validate:
+    # Reusable Workflow aus dem metarepo
     uses: heimgewebe/metarepo/.github/workflows/contracts-validate.yml@contracts-v1
+    permissions: inherit


### PR DESCRIPTION
## Summary
- set explicit workflow name and document minimal token permissions for the contracts workflow
- ensure the reusable contracts validation job inherits the workflow permissions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea4ee5bcbc832c9b176c42b31d8fdf