### PR TITLE
Add license metadata to policy crate

### DIFF
--- a/crates/policy/Cargo.toml
+++ b/crates/policy/Cargo.toml
@@ -2,6 +2,7 @@
 name = "policy"
 version = "0.1.0"
 edition.workspace = true
+license = "MIT"
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
## Summary
- add an MIT license declaration to the policy crate so cargo-deny recognizes it as licensed

## Testing
- cargo check -p policy *(fails: unable to download crates.io index due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb6ef757f4832c916f8b38feba79b1