### PR TITLE
Fix WGX profile schema and uv version

### DIFF
--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -1,4 +1,4 @@
-version: 1
+version: "1"
 repo:
   # Kurzname des Repos (wird automatisch aus git ableitbar sein – hier nur Doku)
   name: auto
@@ -12,6 +12,7 @@ env_priority:
   - termux
 
 tooling:
+  uv: "latest"        # nutze eine verfügbare UV-Version
   python:
     uv: true           # uv ist Standard-Layer für Python-Tools
     precommit: true    # falls .pre-commit-config.yaml vorhanden


### PR DESCRIPTION
## Summary
- declare the WGX profile version as a string to satisfy schema validation
- configure the uv tooling entry to use the latest available release instead of an invalid 3.10 pin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb6efc4224832ca3c6cc46e1179a77