### PR TITLE
Fix rust problem matcher duplicate message

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -20,8 +20,7 @@
         },
         {
           "regexp": "^\\s*\\|\\s*(.*)$",
-          "loop": true,
-          "message": 1
+          "loop": true
         }
       ]
     }


### PR DESCRIPTION
## Summary
- remove the duplicated `message` entry from the Rust problem matcher so it validates with GitHub Actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb6f0237c4832cbbf0396ca65f3390