### PR TITLE
Fix rust problem matcher loop message

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -20,6 +20,7 @@
         },
         {
           "regexp": "^\\s*\\|\\s*(.*)$",
+          "message": 1,
           "loop": true
         }
       ]


### PR DESCRIPTION
## Summary
- add the missing message capture to the looped rust problem matcher pattern so GitHub Actions can load it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eb8d36a21c832c8828b614bf60fda4