### PR TITLE
Fix cargo-deny installation and unblock bans workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,54 +40,8 @@ jobs:
         run: bash scripts/ensure-vendor.sh
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh
-      - name: Install cargo-deny (prebuilt with fallback; deduped)
-        shell: bash
-        run: |
-          set -euo pipefail
-          WANT_VER="${CARGO_DENY_VERSION:-latest}"
-          have() { command -v "$1" >/dev/null 2>&1; }
-          version_of() { "$1" --version 2>/dev/null | awk '{print $2}'; }
-
-          install_cargo_deny() {
-            local want="$1"
-            if have cargo-deny; then
-              local have_ver
-              have_ver="$(version_of cargo-deny || true)"
-              if [[ "$want" == "latest" || "$have_ver" == "$want" ]]; then
-                echo "cargo-deny already installed ($have_ver), keeping it."
-                return 0
-              fi
-            fi
-
-            tmpdir="$(mktemp -d)"
-            trap 'rm -rf "$tmpdir" cargo-deny.tar.gz 2>/dev/null || true' EXIT
-
-            if [[ "$want" == "latest" ]]; then
-              url="https://github.com/EmbarkStudios/cargo-deny/releases/latest/download/cargo-deny-x86_64-unknown-linux-gnu.tar.gz"
-            else
-              url="https://github.com/EmbarkStudios/cargo-deny/releases/download/${want}/cargo-deny-x86_64-unknown-linux-gnu.tar.gz"
-            fi
-
-            echo "Attempting prebuilt cargo-deny from: $url"
-            if curl -fsSL "$url" -o cargo-deny.tar.gz; then
-              tar -xzf cargo-deny.tar.gz -C "$tmpdir"
-              binpath="$(find "$tmpdir" -type f -name 'cargo-deny' -perm -111 | head -n1 || true)"
-              if [[ -n "${binpath:-}" ]]; then
-                mkdir -p "$HOME/.cargo/bin"
-                install -m 0755 "$binpath" "$HOME/.cargo/bin/cargo-deny"
-                echo "Installed prebuilt cargo-deny to $HOME/.cargo/bin."
-                export PATH="$HOME/.cargo/bin:$PATH"
-              else
-                echo "Prebuilt archive did not contain cargo-deny binary; falling back to cargo install."
-                cargo install cargo-deny --locked --force
-              fi
-            else
-              echo "Failed to download prebuilt cargo-deny archive; falling back to cargo install."
-              cargo install cargo-deny --locked --force
-            fi
-          }
-
-          install_cargo_deny "$WANT_VER"
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked --force
 
       - name: cargo-deny (conditional)
         run: |

--- a/deny.toml
+++ b/deny.toml
@@ -15,5 +15,7 @@ confidence-threshold = 0.9
 multiple-versions = "warn"
 wildcards = "deny"
 deny = []
-skip = []
+skip = [
+    { name = "syn", version = "1.0.109", reason = "Required by proc-macro-error in utoipa-gen until upstream removes the legacy dependency." },
+]
 skip-tree = []


### PR DESCRIPTION
## Summary
- replace the bespoke cargo-deny downloader in the security workflow with a straightforward `cargo install` invocation
- whitelist the legacy syn 1.0.109 dependency required by proc-macro-error so cargo-deny bans no longer fails while the upstream crate still depends on it

## Testing
- not run (network restrictions prevented installing cargo-deny to reproduce the workflow locally)


------
https://chatgpt.com/codex/tasks/task_e_68eb8e1020b8832cbfed1239b2731377