### PR TITLE
Fix WGX profile schema compliance and UV install

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -63,7 +63,7 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          uv self update 3.10
+          uv self update
           uv --version
           uv sync --frozen
 

--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -1,4 +1,4 @@
-version: "1"
+version: 1
 repo:
   # Kurzname des Repos (wird automatisch aus git ableitbar sein – hier nur Doku)
   name: auto


### PR DESCRIPTION
## Summary
- update the WGX profile version field to use an integer as expected by the guard workflow
- allow the wgx-guard workflow to pull the latest uv release instead of a non-existent 3.10 version

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb8e1c6130832c8d2309fbb400fe1c