### PR TITLE
Fix GitHub Actions rust matcher message duplication

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -17,7 +17,6 @@
         },
         {
           "regexp": "^\\s*\\|\\s*(.*)$",
-          "message": 1,
           "loop": true
         }
       ]


### PR DESCRIPTION
## Summary
- remove the extra `message` field from the rust problem matcher definition so GitHub Actions can parse it

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ed16e88294832cb61863a285096d61