### PR TITLE
Fix cargo audit workflow command

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -67,4 +67,4 @@ jobs:
       - name: Install cargo-audit (fresh)
         run: cargo install cargo-audit --locked --force
       - name: Run cargo audit
-        run: cargo audit --timeout 90
+        run: cargo audit


### PR DESCRIPTION
## Summary
- remove unsupported --timeout flag from the cargo audit step in the security workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed174eeac4832c8bd8a64517e8ca9f