### PR TITLE
Fix problem matcher loop pattern message

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -17,7 +17,8 @@
         },
         {
           "regexp": "^\\s*\\|\\s*(.*)$",
-          "loop": true
+          "loop": true,
+          "message": 1
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add the required message attribute to the loop pattern in the rust problem matcher

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ed1b782620832cbea608f14871de9f