### PR TITLE
Remove outdated syn skip from deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,7 +15,5 @@ confidence-threshold = 0.9
 multiple-versions = "warn"
 wildcards = "deny"
 deny = []
-skip = [
-    { name = "syn", version = "1.0.109", reason = "Required by proc-macro-error in utoipa-gen until upstream removes the legacy dependency." },
-]
+skip = []
 skip-tree = []


### PR DESCRIPTION
## Summary
- remove the stale skip entry for syn 1.0.109 from deny.toml so cargo-deny no longer warns about an unmatched skip configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed43154c58832c9043f916e25385e8