### PR TITLE
Fix rust problem matcher loop message

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -18,7 +18,7 @@
         {
           "regexp": "^\\s*\\|\\s*(.*)$",
           "loop": true,
-          "message": 1
+          "message": "$1"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- ensure the custom rust problem matcher loop pattern provides a message string

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed4310af20832cb4f9600a73a91208