### PR TITLE
Fix GitHub Actions problem matcher configuration

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -18,7 +18,7 @@
         {
           "regexp": "^\\s*\\|\\s*(.*)$",
           "loop": true,
-          "message": "$1"
+          "message": 1
         }
       ]
     }


### PR DESCRIPTION
## Summary
- set the message group reference in `.github/rust.json` to an integer so the matcher can be parsed by GitHub Actions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ed5b511410832c933694dfad4e94bb