### PR TITLE
Fix CI uv version

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Ensure uv version
         run: |
-          uv self update v0.1.17
+          uv self update v0.1.16
           uv --version
 
       - name: Cache uv


### PR DESCRIPTION
## Summary
- update the CI tools workflow to install uv v0.1.16 instead of the unavailable v0.1.17

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed5ba9b8b8832c84754a0c9a73ad94