### PR TITLE
Fix uv tooling version in WGX profile

### DIFF
--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -11,7 +11,7 @@ env_priority:
 # Toolchain expectations for this repository.
 tooling:
   uv:
-    version: "3.10"
+    version: "0.1.44"
   python:
     version: "3.12"
     uv: true


### PR DESCRIPTION
## Summary
- update the WGX tooling profile to request uv version 0.1.44 instead of the unavailable 3.10 release

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ed5bacbc98832cb90f96c69f3d0338