### PR TITLE
Add scaffold for hausKI minimal server project

### DIFF
--- a/services/minimal-server/README.md
+++ b/services/minimal-server/README.md
@@ -1,0 +1,25 @@
+# HausKI Minimal Server
+
+Dieses Projekt stellt einen minimalen Python/FastAPI-Dienst bereit, der die hausKI Policy-, Ingest- und Event-Log-Schnittstellen abbildet. Der Fokus liegt auf einem schnellen lokalen Start und einer erklärbaren Shadow-Mode-Policy.
+
+## Status
+
+* **Phase:** a) Verzeichnis & Requirements
+* **Implementierung:** Struktur und Abhängigkeitsdefinitionen
+
+## Nächste Schritte
+
+1. Implementierung der FastAPI-Anwendung inklusive Shadow-Mode-Policy.
+2. Aufbau der JSONL-Event-Logik.
+3. Ergänzung automatisierter Tests und Beispielkonfigurationen.
+
+## Entwicklung
+
+Die Abhängigkeiten werden mit `uv` verwaltet. Das lokale Setup erfolgt via:
+
+```bash
+cd services/minimal-server
+uv sync
+```
+
+Weitere Details folgen in den nächsten Implementierungsphasen.

--- a/services/minimal-server/pyproject.toml
+++ b/services/minimal-server/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "hauski-minimal-server"
+version = "0.1.0"
+description = "Minimaler FastAPI-Dienst für Policy, Ingest und Event-Log Schnittstellen von hausKI"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "fastapi>=0.111,<0.112",
+  "uvicorn[standard]>=0.30,<0.31",
+  "pydantic>=2.7,<3",
+  "httpx>=0.27,<0.28",
+  "python-json-logger>=2.0,<3",
+]
+
+[project.optional-dependencies]
+dev = [
+  "ruff>=0.6",
+  "pytest>=8.3",
+  "pytest-asyncio>=0.23",
+]
+
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.uv]
+managed = true
+python-preference = "managed"


### PR DESCRIPTION
## Summary
- create directory structure for the hausKI minimal server service
- define FastAPI and tooling dependencies via a dedicated pyproject

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed6f6bc6c8832c98a1398a20bd78c1