### PR TITLE
Fix CLI model table formatting for empty datasets

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -182,9 +182,7 @@ fn print_models_table(file: &ModelsFile) {
         );
     }
 
-    if !rows.is_empty() {
-        println!("{separator}");
-    }
+    println!("{separator}");
 }
 
 // ---- Konfiguration (YAML) ----


### PR DESCRIPTION
## Summary
- ensure the `hauski-cli models ls` table always prints a closing border even when no models are available

## Testing
- cargo run -p hauski-cli models ls
- HAUSKI_MODELS=/tmp/empty_models.yml cargo run -p hauski-cli models ls

------
https://chatgpt.com/codex/tasks/task_e_68ed716bcab8832caef200a23099b044