### PR TITLE
Restore rust problem matcher schema

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -4,21 +4,16 @@
       "owner": "rustc",
       "pattern": [
         {
-          "regexp": "^(error|warning|note|help)(?:\\[(E\\d{4}|[\\w\\-]+)\\])?:\\s+(.*)$",
-          "message": 3,
+          "regexp": "^(warning|error)(?:\\s*\\[(E\\d{4})\\])?:\\s(.*)$",
+          "severity": 1,
           "code": 2,
-          "severity": 1
+          "message": 3
         },
         {
-          "regexp": "^\\s*-->\\s+([^:]+):(\\d+):(\\d+)$",
+          "regexp": "^\\s*-->\\s(.+):(\\d+):(\\d+)$",
           "file": 1,
           "line": 2,
           "column": 3
-        },
-        {
-          "regexp": "^\\s*\\|\\s*(.*)$",
-          "loop": true,
-          "message": 1
         }
       ]
     }


### PR DESCRIPTION
## Summary
- replace the rust problem matcher with a minimal schema that avoids duplicate `message` properties
- capture severity, error code, and span location for rustc and Clippy diagnostics

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68ed736b34a8832c86bdba0c668e5528