### PR TITLE
hausKI: align shadow policy service with uv tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,47 @@ cargo build --workspace
 cargo test --workspace -- --nocapture
 ```
 
+### Python Shadow Policy API
+
+1. Optional die Python-Extras synchronisieren (uv verwaltet automatisch eine lokale Umgebung):
+
+   ```bash
+   uv sync --extra dev
+   ```
+
+2. Den FastAPI-Dienst lokal starten:
+
+   ```bash
+   uv run uvicorn services.policy_shadow.app:app --reload --port 8085
+   ```
+
+   Alternativ kannst du `just shadow` verwenden. Setze bei Bedarf `HAUSKI_TOKEN=supersecret` und rufe den Dienst anschließend mit dem Header `x-auth: <token>` auf.
+
+3. Beispielaufrufe mit `curl`:
+
+   ```bash
+   curl -X POST http://127.0.0.1:8085/v1/ingest/metrics \
+     -H 'Content-Type: application/json' \
+     -d '{
+       "ts": 1700000000000,
+       "host": "pop-os",
+       "updates": {"packages": 3},
+       "backup": {"last_run": "2024-01-01"},
+       "drift": {"config": []}
+     }'
+
+   curl -X POST http://127.0.0.1:8085/v1/policy/decide \
+     -H 'Content-Type: application/json' \
+     -d '{"context": {"routine": "coffee"}}'
+
+   curl -X POST http://127.0.0.1:8085/v1/policy/feedback \
+     -H 'Content-Type: application/json' \
+     -d '{"decision_id": "abc", "rating": 1.0, "notes": "works"}'
+
+   curl http://127.0.0.1:8085/v1/health/latest
+   curl http://127.0.0.1:8085/version
+   ```
+
 > 💡 **Hinweis auf Offline-Builds:** Bevor du `cargo clippy`, `cargo build` oder
 > `cargo test` ausführst, stelle sicher, dass `vendor/` alle benötigten Crates
 > enthält. Der Helper `scripts/check-vendor.sh` warnt früh mit einer

--- a/justfile
+++ b/justfile
@@ -62,6 +62,9 @@ py-docs-build:
 py-pre-commit:
     uv run pre-commit run --all-files
 
+shadow:
+    uv run uvicorn services.policy_shadow.app:app --reload --port 8085
+
 # Quick vs. Full
 test-quick:
     @echo "running quick tests…"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ required-version = ">=0.7.0"
 ##   - uv:  `uv sync --extra dev`
 ##   - pip: `pip install .[dev]`
 dev = [
+  "fastapi>=0.115",
+  "pydantic>=2.9",
   "ruff>=0.6",
   "pre-commit>=3.8",
   "mkdocs>=1.6",
@@ -27,6 +29,7 @@ dev = [
   "mkdocs-git-revision-date-localized-plugin>=1.3",
   "pytest>=8.3",
   "rich>=13.9",
+  "uvicorn[standard]>=0.32",
 ]
 
 [scripts]

--- a/services/policy_shadow/app.py
+++ b/services/policy_shadow/app.py
@@ -1,0 +1,140 @@
+"""Minimal FastAPI service for HausKI policy experimentation."""
+from __future__ import annotations
+
+import json
+import os
+import platform
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastapi import Depends, FastAPI, Header, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field
+
+APP_VERSION = os.getenv("HAUSKI_VERSION", "0.1.0")
+TOKEN_ENV = "HAUSKI_TOKEN"
+EVENT_BASE_ENV = "HAUSKI_DATA"
+
+
+def _event_dir() -> Path:
+    base = Path(os.getenv(EVENT_BASE_ENV, Path.home() / ".hauski"))
+    events_dir = base / "events"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    return events_dir
+
+
+def append_event(kind: str, payload: Dict[str, Any]) -> None:
+    """Append an event line using the shared HausKI schema."""
+    events_dir = _event_dir()
+    now = datetime.now(timezone.utc)
+    filename = events_dir / f"{now.astimezone().strftime('%Y-%m')}.jsonl"
+
+    node_id = os.getenv("HAUSKI_NODE_ID") or platform.node() or "unknown"
+    event_line = {
+        "id": os.getenv("HAUSKI_EVENT_ID", str(uuid.uuid4())),
+        "node_id": node_id,
+        "ts": int(now.timestamp() * 1000),
+        "kind": kind,
+        "payload": payload,
+    }
+
+    with filename.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event_line, ensure_ascii=False))
+        handle.write("\n")
+
+
+class MetricsIngest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    ts: int = Field(..., description="Client-side timestamp in milliseconds")
+    host: str = Field(..., description="Hostname emitting the metrics")
+    updates: Dict[str, Any]
+    backup: Dict[str, Any]
+    drift: Dict[str, Any]
+
+
+class PolicyDecisionRequest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    ts: Optional[int] = Field(None, description="Client timestamp in milliseconds")
+    context: Dict[str, Any] = Field(default_factory=dict)
+
+
+class PolicyDecisionResponse(BaseModel):
+    action: str
+    score: float
+    why: str
+    context: Dict[str, Any]
+
+
+class PolicyFeedback(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    decision_id: Optional[str] = None
+    rating: Optional[float] = None
+    notes: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+app = FastAPI(title="HausKI Shadow Policy API", version=APP_VERSION)
+
+_latest_metrics: Dict[str, Any] = {}
+
+
+def require_token(x_auth: Optional[str] = Header(default=None)) -> None:
+    expected = os.getenv(TOKEN_ENV)
+    if expected and x_auth != expected:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid or missing x-auth token",
+        )
+
+
+@app.post("/v1/ingest/metrics", dependencies=[Depends(require_token)])
+def ingest_metrics(payload: MetricsIngest) -> Dict[str, str]:
+    global _latest_metrics
+    _latest_metrics = payload.model_dump()
+    append_event("metrics.ingest", _latest_metrics)
+    return {"status": "ok"}
+
+
+@app.post("/v1/policy/decide", dependencies=[Depends(require_token)], response_model=PolicyDecisionResponse)
+def policy_decide(request: PolicyDecisionRequest) -> PolicyDecisionResponse:
+    now = datetime.now().astimezone()
+    hour = now.hour
+    if hour < 12:
+        action = "remind.morning"
+        why = "Morning shadow policy recommendation"
+    elif hour < 18:
+        action = "remind.afternoon"
+        why = "Afternoon shadow policy recommendation"
+    else:
+        action = "remind.evening"
+        why = "Evening shadow policy recommendation"
+
+    response = PolicyDecisionResponse(
+        action=action,
+        score=0.5,
+        why=why,
+        context={"requested": request.context, "observed_hour": hour},
+    )
+
+    append_event("policy.shadow_decide", response.model_dump())
+    return response
+
+
+@app.post("/v1/policy/feedback", dependencies=[Depends(require_token)])
+def policy_feedback(feedback: PolicyFeedback) -> Dict[str, str]:
+    append_event("policy.feedback", feedback.model_dump())
+    return {"status": "queued"}
+
+
+@app.get("/v1/health/latest", dependencies=[Depends(require_token)])
+def health_latest() -> Dict[str, Any]:
+    return {"status": "ok", "metrics": _latest_metrics or None}
+
+
+@app.get("/version")
+def version() -> Dict[str, str]:
+    return {"version": APP_VERSION}


### PR DESCRIPTION
## Summary
- move the FastAPI shadow policy app under services/policy_shadow and update the quickstart docs and justfile entry point
- consolidate the Python dependencies into the existing uv-managed dev extras for a single installation path

## Testing
- python -m compileall services/policy_shadow/app.py

------
https://chatgpt.com/codex/tasks/task_e_68ee61216948832cad480a89e68db955