### PR TITLE
Fix uv workflow version

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Ensure uv version
         run: |
-          uv self update v0.1.16
+          uv self update
           uv --version
 
       - name: Cache uv


### PR DESCRIPTION
## Summary
- update the CI tools workflow to stop pinning uv to the unavailable v0.1.16 release
- rely on `uv self update` to install the latest available version

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef29fdd8dc832c99e378140798a490