### PR TITLE
Fix WGX profile schema

### DIFF
--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -1,4 +1,4 @@
-version: "1.0"
+version: 1
 
 # Ordered list of preferred execution environments for WGX tasks.
 env_priority:
@@ -10,8 +10,7 @@ env_priority:
 
 # Toolchain expectations for this repository.
 tooling:
-  uv:
-    version: "0.1.44"
+  uv: "0.1.44"
   python:
     version: "3.12"
     uv: true


### PR DESCRIPTION
## Summary
- update the WGX profile version field to use the expected schema version
- set the uv tooling entry to a direct version string to avoid the invalid 3.10 reference

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef2a01528c832c979afabb50cabc8d