### PR TITLE
Ensure MkDocs minify plugin installed during CI docs build

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Sync dev deps
         run: uv sync --group dev --frozen
 
+      - name: Install MkDocs plugins
+        run: uv pip install mkdocs-minify-plugin mkdocs-git-revision-date-localized-plugin
+
       - name: Ruff check
         run: uv run ruff check .
 


### PR DESCRIPTION
## Summary
- install the MkDocs minify and git revision date plugins in the CI tools workflow so the docs build has required plugins available

## Testing
- Not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68f3b18f2ca0832cb12129d49cffb26f