### PR TITLE
Ensure config log capture uses trace level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,6 +632,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
+ "tempfile",
  "thiserror",
  "tokio",
  "tower",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -29,3 +29,4 @@ utoipa = { version = "5", features = ["axum_extras"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 serial_test = "3"
+tempfile = "3"


### PR DESCRIPTION
## Summary
- ensure the config test log capture subscribes up to TRACE so warnings are never filtered out

## Testing
- cargo test -p hauski-core config::tests

------
https://chatgpt.com/codex/tasks/task_e_68f414a1f2f8832ca1ad75d1b5407a16