### PR TITLE
Add optional feed validation workflow

### DIFF
--- a/.github/workflows/validate-aussen-optional.yml
+++ b/.github/workflows/validate-aussen-optional.yml
@@ -4,7 +4,8 @@ on:
     branches: [ main ]
   pull_request:
   workflow_dispatch:
-
+permissions:
+  contents: read
 jobs:
   v:
     uses: heimgewebe/metarepo/.github/workflows/reusable-validate-jsonl.yml@contracts-v1


### PR DESCRIPTION
## Summary
- add optional GitHub Actions workflow to validate export feed against external schema

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4b2f42744832ca9e832590eb8092e