### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,6 @@
 name: coverage
+permissions:
+  contents: read
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]


### PR DESCRIPTION
Potential fix for [https://github.com/heimgewebe/hausKI/security/code-scanning/1](https://github.com/heimgewebe/hausKI/security/code-scanning/1)

The best way to fix this problem is to add an explicit `permissions` block to the workflow. This block can be applied at the root level (which affects all jobs by default), or at the job level. Since this workflow only has a single job (`cov`), placing it at the root is simplest and makes it clear to future readers and maintainers. The minimal safe starting point is to set `contents: read`, which allows read access to repository contents but not write access. If later you need specific write permissions (for example, to update issues or PRs), those can be granted individually. The change can be applied by adding the block immediately after the `name:` line, before the `on:` trigger.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
