### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: release
 on:
   push:
     tags: ['v*.*.*']
+permissions:
+  contents: write
 jobs:
   publish:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/heimgewebe/hausKI/security/code-scanning/2](https://github.com/heimgewebe/hausKI/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow, limiting the permissions of the GITHUB_TOKEN to those required for the release process. The least privilege for softprops/action-gh-release is usually `contents: write`. Place the permissions block at the root level (before `jobs:`) so it affects all jobs (including `publish`). You only need to edit `.github/workflows/release.yml` and add the required `permissions` key, for example:

```yaml
permissions:
  contents: write
```

No other actions or steps in this workflow require further permissions. Make this addition above the `jobs:` block, typically after the `name`, `on`, and tag patterns.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
