### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -15,6 +15,8 @@ on:
       - "Cargo.toml"
   workflow_dispatch:
 
+permissions:
+  contents: read
 jobs:
   guard:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/heimgewebe/hausKI/security/code-scanning/3](https://github.com/heimgewebe/hausKI/security/code-scanning/3)

The optimal fix is to set an explicit `permissions` block for the workflow, restricting GITHUB_TOKEN permissions according to the principle of least privilege. Since the workflow only checks files, runs Python scripts, and installs packages, and does not modify repository content, the workflow requires only read access. Therefore, you should set `permissions: contents: read` at the workflow root, above the `jobs:` block (e.g., between lines 17 and 18). This will apply to all jobs unless overridden, reducing permission scope and adhering to security best practices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
