### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/wgx-smoke.yml
+++ b/.github/workflows/wgx-smoke.yml
@@ -1,4 +1,5 @@
 name: wgx-smoke (disabled)
+permissions: {}
 on:
   # Only manually startable to keep the file valid,
   # but no longer appears "red" in normal CI.


### PR DESCRIPTION
Potential fix for [https://github.com/heimgewebe/hausKI/security/code-scanning/4](https://github.com/heimgewebe/hausKI/security/code-scanning/4)

To fix this issue, add a `permissions` key at the root level of the workflow file, directly under the workflow `name` and before the `on` block (or immediately after the `on` block; both are accepted syntax). Since the workflow does not need any permissions, the strictest and most future-safe setting is `permissions: {}`, which disables all `GITHUB_TOKEN` permissions for the workflow. This ensures even if steps are later added, they will not be able to perform any GitHub API actions unless permissions are explicitly added and least privilege is considered. Edit `.github/workflows/wgx-smoke.yml` to add `permissions: {}` at the appropriate place.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
