### PR TITLE
Fix uv version in wgx guard workflow

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -65,7 +65,7 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          uv self update 3.10
+          uv self update 0.1.44
           uv --version
           uv sync --frozen
 


### PR DESCRIPTION
## Summary
- update the wgx guard workflow to pin uv to version 0.1.44 instead of the nonexistent 3.10 release

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4e404b6ec832c8b2e6765d65462fc