### PR TITLE
Configure secret scanning ignores for vendored fixtures

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,4 @@
+paths-ignore:
+  - "vendor/**/tests/**"
+  - "vendor/**/testdata/**"
+  - "vendor/**/examples/**"

--- a/justfile
+++ b/justfile
@@ -33,6 +33,10 @@ run-cli ARGS='':
 vendor:
     mkdir -p vendor
     cargo vendor --locked --respect-source-config > /dev/null
+    scripts/vendor-prune.sh
+
+vendor-prune:
+    scripts/vendor-prune.sh
 
 vendor-archive:
     rm -f hauski-vendor-snapshot.tar.zst

--- a/scripts/vendor-prune.sh
+++ b/scripts/vendor-prune.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Test-/Example-Ordner im vendor/ entfernen (nur Quellen, keine Build-Dateien)
+if [ -d vendor ]; then
+  find vendor -type d \( -name tests -o -name testdata -o -name examples \) -print0 | xargs -0 rm -rf
+fi


### PR DESCRIPTION
## Summary
- configure GitHub secret scanning to ignore vendored test and example paths
- add a vendor pruning script and wire it into the vendoring workflow

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f4e45c145c832c94181c7895df5d18