### PR TITLE
Ensure CI specifies Rust toolchain inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
+      toolchain: stable
       RUSTFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v5
@@ -160,6 +161,7 @@ jobs:
         run: echo "::add-matcher::.github/rust.json"
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.toolchain }}
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: Check vendor snapshot
@@ -196,11 +198,15 @@ jobs:
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      toolchain: stable
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.toolchain }}
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh
       - uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Summary
- set a default Rust toolchain for the fmt/clippy/test workflow job and pass it to dtolnay/rust-toolchain
- configure the security job to use the same stable toolchain input

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f4e799b1e0832ca5105cc0a75f8988