### PR TITLE
Ensure coverage workflow has actions write permission

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,9 @@
 name: coverage
 permissions:
   contents: read
+  actions: write
+
+# actions:write is required for rust-cache and upload-artifact to work
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]


### PR DESCRIPTION
## Summary
- add actions: write permission to the coverage workflow so rust-cache and upload-artifact can operate
- document why the extra permission is required

## Testing
- not run (workflow configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68f4e8bee124832c8389094ce6e01029