### PR TITLE
Stop pruning vendored fixtures

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,4 +1,12 @@
+# Ignore vendored test fixtures & examples to avoid false positives
+# (z.B. Test-Keys in Dependencies). Wir löschen nichts aus vendor/,
+# damit Cargo-Checksummen intakt bleiben.
 paths-ignore:
   - "vendor/**/tests/**"
   - "vendor/**/testdata/**"
+  - "vendor/**/fixtures/**"
   - "vendor/**/examples/**"
+  - "vendor/**/example/**"
+
+# Optional: eigene Pfade für lokale Tests/Demos
+# - "crates/**/tests/fixtures/**"

--- a/docs/runbooks/troubleshooting.md
+++ b/docs/runbooks/troubleshooting.md
@@ -29,3 +29,14 @@ just run-cli -- models pull <model-id>
 
 Replace `<model-id>` with the identifier you need (for example `whisper-base.en`).
 
+## Secret-scanning noise from vendored fixtures
+
+GitHub Advanced Security may flag sample keys or credentials that live in vendored
+dependencies under `vendor/`. We keep the vendor tree intact—deleting files would
+invalidate Cargo's `.cargo-checksum.json` and break builds. Instead, the
+configuration in `.github/secret_scanning.yml` ignores common fixture locations in
+vendored crates. If you encounter alerts for these paths, confirm the files are
+vendored test assets and close the alerts as "ignored by configuration". Never
+remove files from `vendor/`; adjust the ignore list if additional fixture paths
+are needed.
+

--- a/justfile
+++ b/justfile
@@ -33,10 +33,6 @@ run-cli ARGS='':
 vendor:
     mkdir -p vendor
     cargo vendor --locked --respect-source-config > /dev/null
-    scripts/vendor-prune.sh
-
-vendor-prune:
-    scripts/vendor-prune.sh
 
 vendor-archive:
     rm -f hauski-vendor-snapshot.tar.zst

--- a/scripts/vendor-prune.sh
+++ b/scripts/vendor-prune.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-# Test-/Example-Ordner im vendor/ entfernen (nur Quellen, keine Build-Dateien)
-if [ -d vendor ]; then
-  find vendor -type d \( -name tests -o -name testdata -o -name examples \) -print0 | xargs -0 rm -rf
-fi


### PR DESCRIPTION
## Summary
- expand GitHub secret scanning ignores to cover vendored fixtures and examples without deleting files
- remove the vendor pruning script to keep cargo vendor checksums intact
- drop the corresponding just recipes that invoked the pruning script
- document troubleshooting guidance for handling secret-scanning noise in vendored fixtures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4ebe898e8832ca29bb5a5b4a80fdf