### PR TITLE
Document required toolchain input in workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,6 +29,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
+          # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
+          toolchain: stable
           components: llvm-tools-preview
       - name: Ensure vendor snapshot
         run: bash scripts/ensure-vendor.sh

--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Enable Rust problem matchers
         run: echo "::add-matcher::.github/rust.json"
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
+          toolchain: stable
       - uses: Swatinem/rust-cache@v2
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh

--- a/.github/workflows/policy-ci.yml
+++ b/.github/workflows/policy-ci.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
+          toolchain: stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
+          toolchain: stable
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh
       - name: Build (release, locked)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,6 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
+          toolchain: stable
       - name: Ensure vendor snapshot
         run: bash scripts/ensure-vendor.sh
       - name: Check vendor snapshot
@@ -60,6 +63,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
+          toolchain: stable
       - name: Ensure vendor snapshot
         run: bash scripts/ensure-vendor.sh
       - name: Check vendor snapshot

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
+          toolchain: stable
       - name: Create vendor tree
         run: cargo vendor --locked --respect-source-config > /dev/null
       - name: Verify vendor snapshot


### PR DESCRIPTION
## Summary
- document why the `toolchain` input is passed to `dtolnay/rust-toolchain` in the Rust workflows to prevent future regressions

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f5dbe1b8fc832ca0d3e302960a6d87