### PR TITLE
docs: document review cycle v1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,12 @@ Beispielabfragen für Dashboards oder die Prometheus-Konsole:
 
 ---
 
+## Review-Zyklus & Flags
+Siehe [docs/review-cycle.md](docs/review-cycle.md) für Speicherpfade, Index und Hook-Verhalten.
+Der optionale Upstream für Chat lässt sich via `chat_upstream_url` setzen.
+
+---
+
 ## Memory & semantische Suche
 
 HausKI bringt mit [semantAH](docs/semantah.md) eine semantische Gedächtnisschicht mit. Der Bootstrap enthält Dokumentation, Konfiguration, Skripte und Rust-Scaffolds für Index, Graph und Related-Blöcke. Starte mit dem Quickstart in `docs/semantah.md`, um Ollama einzubinden, Seeds zu laden und die `/index`-Endpunkte zu testen.

--- a/docs/review-cycle.md
+++ b/docs/review-cycle.md
@@ -1,0 +1,9 @@
+# Review-Zyklus v1.4
+- Reports liegen unter `~/.hauski/review/<repo>/`, im Repo nur Symlink `.hauski-reports`.
+- Globaler Index: `~/.hauski/review/index.json`.
+- Hook arbeitet mit `flock`, erkennt "Doc-only" Changes.
+- Asynchron optional via `HAUSKI_ASYNC=1`.
+- Perspektive: Daemon `hauski-reviewd` (watch & queue).
+
+## Flags
+- `chat_upstream_url`: optionaler OpenAI-kompatibler Upstream (z. B. llama.cpp Server).


### PR DESCRIPTION
## Summary
- add review cycle v1.4 documentation outlining report locations, hook behavior, and async mode
- link the new document from the README and mention the chat upstream flag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5e8ab4ad4832ca19bb460ce939a4e