### PR TITLE
Remove redundant toolchain env from CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
        ))
     runs-on: ubuntu-latest
     env:
-      toolchain: stable
       RUSTFLAGS: -Dwarnings
     timeout-minutes: 12
     steps:
@@ -69,7 +68,7 @@ jobs:
         run: echo "::add-matcher::.github/rust.json"
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: stable
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: Check vendor snapshot
@@ -151,7 +150,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      toolchain: stable
       RUSTFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v5
@@ -161,7 +159,7 @@ jobs:
         run: echo "::add-matcher::.github/rust.json"
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: stable
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: Check vendor snapshot
@@ -198,15 +196,13 @@ jobs:
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      toolchain: stable
     steps:
       - uses: actions/checkout@v5
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.toolchain }}
+          toolchain: stable
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh
       - uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Summary
- drop unused `toolchain` environment variable assignments in CI jobs now that the toolchain input is configured directly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5ed6bc090832c8eca0f1caea5de1b