### PR TITLE
Clarify review symlink usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,11 @@ Alternativ steht der Snapshot auch als Artefakt des Workflows
 
 ### Codex-Review-Ablage
 
-Codex-Läufe schreiben ihre Rohdaten nach `~/.hauski/review/hauski/`. Lege dir im Repo optional einen Symlink `ln -s ~/.hauski/review/hauski .hauski-reports` an; dadurch bleiben Logs, Pläne und Canvas-Dateien persistent, ohne ins Repo zu geraten.
+Codex-Läufe schreiben ihre Rohdaten nach `~/.hauski/review/hauski/`. Lege dir im Repo optional einen Symlink von `~/.hauski/review/hauski` auf `.hauski-reports` an; dadurch bleiben Logs, Pläne und Canvas-Dateien persistent, ohne ins Repo zu geraten.
+
+```bash
+ln -s ~/.hauski/review/hauski .hauski-reports
+```
 
 Nutze `just codex:doctor`, um vor einem Run schnell zu prüfen, ob eine lokale `codex`-Installation gefunden wird oder automatisch auf `npx @openai/codex@1.0.0` zurückgefallen wird.
 
@@ -314,7 +318,13 @@ Beispielabfragen für Dashboards oder die Prometheus-Konsole:
 ---
 
 ## Review-Zyklus & Flags
-Siehe [docs/review-cycle.md](docs/review-cycle.md) für Speicherpfade, Index und Hook-Verhalten.
+- Speicherpfade: Reports landen unter `~/.hauski/review/<repo>/`, optionaler Symlink `.hauski-reports` hält sie außerhalb des Repos.
+- Index: `~/.hauski/review/index.json` führt alle Läufe zusammen.
+- Hook & flock: Git-Hooks nutzen `flock` und erkennen Doc-only-Changes.
+- Async-Mode: `HAUSKI_ASYNC=1` legt Läufe in die Queue und gibt schneller frei.
+- Ausblick: `hauski-reviewd` soll als Daemon das Review-Verzeichnis beobachten.
+
+Siehe [docs/review-cycle.md](docs/review-cycle.md) für Details.
 Der optionale Upstream für Chat lässt sich via `chat_upstream_url` setzen.
 
 ---

--- a/docs/review-cycle.md
+++ b/docs/review-cycle.md
@@ -1,9 +1,28 @@
 # Review-Zyklus v1.4
-- Reports liegen unter `~/.hauski/review/<repo>/`, im Repo nur Symlink `.hauski-reports`.
-- Globaler Index: `~/.hauski/review/index.json`.
-- Hook arbeitet mit `flock`, erkennt "Doc-only" Changes.
-- Asynchron optional via `HAUSKI_ASYNC=1`.
-- Perspektive: Daemon `hauski-reviewd` (watch & queue).
+
+Der aktuelle Review-Zyklus dokumentiert, wo Codex-Läufe landen, wie die Hooks
+arbeiten und welche Erweiterungen in Arbeit sind.
+
+## Speicherpfade & Index
+- Primäre Ablage: `~/.hauski/review/<repo>/` enthält Reports, Canvas-Dateien und
+  Logs des jeweiligen Repositories.
+- Repository-seitig empfiehlt sich ein Symlink `ln -s ~/.hauski/review/hauski
+  .hauski-reports`, damit Artefakte lokal bleiben, aber nicht ins Repo gelangen.
+  > ⚠️  Symlink nicht committen; die Artefakte liegen ausschließlich lokal.
+- Ein globaler Index bündelt alle Runs unter `~/.hauski/review/index.json` und
+  wird vom Hook laufend aktualisiert.
+
+## Hook-Verhalten
+- Das Git-Hook-Skript nutzt `flock`, um parallele Läufe zu verhindern.
+- Erkennung von "Doc-only"-Changes vermeidet unnötige, teure Checks.
+- Für opt-in Asynchronität lässt sich `HAUSKI_ASYNC=1` setzen; der Hook legt
+  Runs dann in die Queue und kehrt schneller zum Commit zurück.
+
+## Ausblick: `hauski-reviewd`
+- Geplant ist ein Daemon, der das Review-Verzeichnis überwacht, neue Läufe
+  einsammelt und in eine Warteschlange einsortiert (`watch & queue`).
+- Ziel ist ein robuster Offline-Workflow ohne manuelle Trigger.
 
 ## Flags
-- `chat_upstream_url`: optionaler OpenAI-kompatibler Upstream (z. B. llama.cpp Server).
+- `chat_upstream_url`: optionaler OpenAI-kompatibler Upstream (z. B.
+  llama.cpp-Server).


### PR DESCRIPTION
## Summary
- expand docs/review-cycle.md into a short standalone note covering storage, hook behaviour, async mode and roadmap
- surface the key review-cycle touchpoints directly in the README with a link to the detailed doc
- highlight the optional symlink command and remind readers that reports stay local

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6003cd60c832ca69cd5afbed68075