### PR TITLE
Ensure CI workflow always sets Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
         required: false
 
 env:
-  RUST_TOOLCHAIN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.toolchain || 'stable' }}
+  RUST_TOOLCHAIN: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.toolchain != '' && github.event.inputs.toolchain) || 'stable' }}
 
 permissions:
   id-token: write
@@ -76,6 +76,7 @@ jobs:
         run: echo "::add-matcher::.github/rust.json"
       - uses: dtolnay/rust-toolchain@stable
         with:
+          # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
@@ -167,6 +168,7 @@ jobs:
         run: echo "::add-matcher::.github/rust.json"
       - uses: dtolnay/rust-toolchain@stable
         with:
+          # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
@@ -210,6 +212,7 @@ jobs:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
         with:
+          # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh


### PR DESCRIPTION
## Summary
- ensure the CI workflow always provides a toolchain value to the Rust setup action
- document why the toolchain input is explicitly set

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f6136edb4c832c85d0e1aa440276d7