### PR TITLE
Ensure CI workflow always sets toolchain input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   RUST_TOOLCHAIN: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.toolchain != '' && github.event.inputs.toolchain) || 'stable' }}
+  toolchain: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.toolchain != '' && github.event.inputs.toolchain) || 'stable' }}
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary
- ensure the CI workflow exports a `toolchain` environment variable derived from the requested or default Rust toolchain so dependent steps receive the value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6610b88d0832c8d9dff30c2ff1a0e