### PR TITLE
Ensure contracts workflow sets toolchain input

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -14,3 +14,6 @@ jobs:
     # Reusable Workflow aus dem metarepo
     uses: heimgewebe/metarepo/.github/workflows/contracts-validate.yml@contracts-v1
     permissions: inherit
+    with:
+      # Explicit input required by reusable workflow to select the Rust toolchain.
+      toolchain: stable


### PR DESCRIPTION
## Summary
- add the required `toolchain` input when invoking the reusable contracts validation workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f761a54d74832c831328288e486280