### PR TITLE
Polish hauski-reviewd service configuration

### DIFF
--- a/.systemd/hauski-reviewd.service
+++ b/.systemd/hauski-reviewd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=hausKI review daemon
+
+[Service]
+Type=oneshot
+Environment=REPO_DIR=$REPO_DIR
+WorkingDirectory=${REPO_DIR}
+ExecStart=${REPO_DIR}/scripts/hauski-reviewd.sh
+StandardOutput=journal
+StandardError=journal

--- a/.systemd/hauski-reviewd.timer
+++ b/.systemd/hauski-reviewd.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=hausKI review daemon timer
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Unit=hauski-reviewd.service
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target

--- a/README.md
+++ b/README.md
@@ -349,6 +349,19 @@ Beispielabfragen für Dashboards oder die Prometheus-Konsole:
   - Docs strikt: `just py-docs-build`
   - Hooks lokal prüfen: `just py-pre-commit`
 
+
+## Review-Daemon
+
+Ein systemd-User-Timer startet alle fünf Minuten genau einen Review-Lauf und verhindert Parallelität per Lockfile `~/.hauski/review/hauski.lock`. Logs landen unter `~/.hauski/review/hauski/review-YYYYmmdd-HHMMSS.log`.
+
+```bash
+just reviewd:install
+just reviewd:enable
+just reviewd:status
+```
+
+Der Timer lädt optional Variablen aus `.env` im Repo-Root und bevorzugt `just review-quick` (Fallback auf `just review`). Perspektivisch ist ein Wechsel auf eine Path-Unit oder ein eventgetriebenes Setup (Git-Hook, inotify) vorgesehen.
+
 ---
 
 ## Review-Zyklus & Flags

--- a/justfile
+++ b/justfile
@@ -108,3 +108,21 @@ emit-event id='auto' kind='debug.test' payload='{"ok":true}':
     @echo "Emitting event: {{kind}}"
     if [ "{{id}}" = "auto" ]; then id_arg=""; else id_arg="{{id}}"; fi
     NODE_ID="$(hostname)" KIND="{{kind}}" PAYLOAD='{{payload}}' ./scripts/emit_event_line.sh ${id_arg}
+
+reviewd:install:
+    repo_dir="$$(git rev-parse --show-toplevel)"; \
+    config_dir="$$HOME/.config/systemd/user"; \
+    mkdir -p "$$config_dir"; \
+    if command -v envsubst >/dev/null 2>&1; then \
+        env REPO_DIR="$$repo_dir" envsubst < .systemd/hauski-reviewd.service > "$$config_dir/hauski-reviewd.service"; \
+    else \
+        sed "s|\\$REPO_DIR|$$repo_dir|g" .systemd/hauski-reviewd.service > "$$config_dir/hauski-reviewd.service"; \
+    fi; \
+    cp .systemd/hauski-reviewd.timer "$$config_dir/hauski-reviewd.timer"; \
+    systemctl --user daemon-reload
+
+reviewd:enable:
+    systemctl --user enable --now hauski-reviewd.timer
+
+reviewd:status:
+    systemctl --user status hauski-reviewd.timer hauski-reviewd.service || true

--- a/scripts/hauski-reviewd.sh
+++ b/scripts/hauski-reviewd.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+LOCK_FILE="$HOME/.hauski/review/hauski.lock"
+LOG_DIR="$HOME/.hauski/review/hauski"
+mkdir -p "$(dirname "$LOCK_FILE")" "$LOG_DIR"
+
+exec {fd}>"$LOCK_FILE" || exit 0
+if ! flock -n "$fd"; then
+  echo "hauski-reviewd: already running"
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR_DEFAULT="$(cd "$SCRIPT_DIR/.." && pwd)"
+if [[ -n "${REPO_DIR:-}" && -d "${REPO_DIR}/.git" ]]; then
+  cd "$REPO_DIR"
+else
+  cd "$REPO_DIR_DEFAULT"
+fi
+
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env || true
+  set +a
+fi
+
+log_file="$LOG_DIR/review-$(date +%Y%m%d-%H%M%S).log"
+echo "hauski-reviewd: starting review run at $(date --iso-8601=seconds)" | tee -a "$log_file"
+
+if ! command -v just >/dev/null 2>&1; then
+  echo "hauski-reviewd: 'just' command not found" | tee -a "$log_file"
+  exit 127
+fi
+
+if just --show review-quick >/dev/null 2>&1; then
+  review_cmd=(just review-quick)
+  echo "hauski-reviewd: running 'just review-quick'" | tee -a "$log_file"
+else
+  review_cmd=(just review)
+  echo "hauski-reviewd: running 'just review' (fallback)" | tee -a "$log_file"
+fi
+
+set +e
+"${review_cmd[@]}" 2>&1 | tee -a "$log_file"
+status=${PIPESTATUS[0]}
+set -e
+
+echo "hauski-reviewd: finished with status $status" | tee -a "$log_file"
+exit "$status"


### PR DESCRIPTION
## Summary
- send hauski-reviewd output to the user journal and rely on the timer for activation
- tighten the timer cadence and add a fallback when envsubst is unavailable during installation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f76fc770f8832c960e8b3ed956adc7