### PR TITLE
Pin checkout action to v4 across CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,11 @@ on:
 env:
   # Provide the toolchain input in both lowercase and uppercase variants so
   # that reusable scripts checking `$toolchain` always receive a value.
-  toolchain: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.toolchain != '' && github.event.inputs.toolchain) || 'stable' }}
-  RUST_TOOLCHAIN: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.toolchain != '' && github.event.inputs.toolchain) || 'stable' }}
+  #
+  # For workflow_dispatch events, prefer the provided input when present; for all
+  # other events (or empty inputs) fall back to the stable toolchain.
+  toolchain: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.toolchain) || 'stable' }}
+  RUST_TOOLCHAIN: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.toolchain) || 'stable' }}
 
 permissions:
   id-token: write
@@ -36,7 +39,7 @@ jobs:
       docs:  ${{ steps.filter.outputs.docs }}
       sh:    ${{ steps.filter.outputs.sh }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - uses: dorny/paths-filter@v3
@@ -72,7 +75,7 @@ jobs:
       RUSTFLAGS: -Dwarnings
     timeout-minutes: 12
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Enable Rust problem matchers
@@ -102,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - uses: lycheeverse/lychee-action@v2
@@ -139,7 +142,7 @@ jobs:
        ))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Emit TODO notice
@@ -164,7 +167,7 @@ jobs:
     env:
       RUSTFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Enable Rust problem matchers
@@ -207,7 +210,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
@@ -237,7 +240,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- pin every actions/checkout usage in the CI workflow to the stable v4 release for predictable behavior

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f785a54a20832c90a6531c82c3cde9