### PR TITLE
Harden event validation workflow

### DIFF
--- a/.github/workflows/validate-events.yml
+++ b/.github/workflows/validate-events.yml
@@ -1,0 +1,32 @@
+name: validate hausKI events
+
+on:
+  push:
+    paths:
+      - "export/**"
+      - "data/**"
+      - "logs/**"
+      - ".github/workflows/validate-events.yml"
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-jsonl:
+    if: ${{ hashFiles(matrix.file) != '' }}
+    name: "events.jsonl schema check"
+    uses: heimgewebe/metarepo/.github/workflows/reusable-validate-jsonl.yml@contracts-v1
+    strategy:
+      fail-fast: false
+      matrix:
+        file:
+          - export/events.jsonl
+          - data/events.jsonl
+          - logs/events.jsonl
+    with:
+      jsonl_path: ${{ matrix.file }}
+      schema_url: https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/event.line.schema.json
+      strict: false
+      validate_formats: true


### PR DESCRIPTION
## Summary
- add a contents-read permission block to the validation workflow
- guard the reusable workflow invocation so it only runs when the JSONL file exists

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f84b06f9e8832ca878c8a9a91d053e