### PR TITLE
Log resolved Rust toolchain selection in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,13 @@ jobs:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Enable Rust problem matchers
         run: echo "::add-matcher::.github/rust.json"
+      - name: Show resolved toolchain
+        run: echo "Using toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}"
       - uses: dtolnay/rust-toolchain@stable
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          # Fall back to "stable" if the workflow-level environment variable is empty.
+          toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: Check vendor snapshot
@@ -175,10 +178,13 @@ jobs:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Enable Rust problem matchers
         run: echo "::add-matcher::.github/rust.json"
+      - name: Show resolved toolchain
+        run: echo "Using toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}"
       - uses: dtolnay/rust-toolchain@stable
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          # Fall back to "stable" if the workflow-level environment variable is empty.
+          toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: Check vendor snapshot
@@ -216,9 +222,12 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
+      - name: Show resolved toolchain
+        run: echo "Using toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}"
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          # Fall back to "stable" if the workflow-level environment variable is empty.
+          toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}
       - uses: Swatinem/rust-cache@v2
       - name: Build hauski-cli
         run: cargo build -p hauski-cli
@@ -246,10 +255,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
+      - name: Show resolved toolchain
+        run: echo "Using toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}"
       - uses: dtolnay/rust-toolchain@stable
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          # Fall back to "stable" if the workflow-level environment variable is empty.
+          toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh
       - uses: taiki-e/install-action@v2


### PR DESCRIPTION
## Summary
- log the resolved Rust toolchain at the start of each job that installs it so the CI logs show which channel ran

## Testing
- not run (workflow change)

------
https://chatgpt.com/codex/tasks/task_e_68f89e294ee8832cbe62c08cf166ec16