### PR TITLE
Update uv requirement to 0.7.x

### DIFF
--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -10,7 +10,7 @@ env_priority:
 
 # Toolchain expectations for this repository.
 tooling:
-  uv: "0.1.44"
+  uv: "0.7.x"
   python:
     version: "3.12"
     uv: true


### PR DESCRIPTION
## Summary
- bump the WGX uv tool expectation to version 0.7.x

## Testing
- `uv sync --upgrade` *(fails: unable to reach pypi.org due to tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_68f9bbb6d28c832cbf31f333667eb678