### PR TITLE
Add toolchain ADR and optional metrics smoke test

### DIFF
--- a/crates/core/tests/metrics_smoke.rs
+++ b/crates/core/tests/metrics_smoke.rs
@@ -1,0 +1,56 @@
+//! Minimaler Smoke-Test für `/metrics`.
+//! 
+//! Dieser Test ist bewusst als `#[ignore]` markiert, damit reguläre CI-Läufe
+//! nicht scheitern, wenn kein Server läuft. Er kann gezielt aktiviert werden:
+//!
+//! ```bash
+//! HAUSKI_TEST_BASE_URL="http://127.0.0.1:8080" \
+//!   cargo test -p hauski-core --test metrics_smoke -- --ignored --nocapture
+//! ```
+//!
+//! Erwartung: Ein laufender hausKI-Server (z. B. `hauski-cli serve`) exponiert
+//! Prometheus-Metriken unter GET /metrics (Content-Type text/plain; version=0.0.4).
+
+use reqwest::StatusCode;
+
+fn base_url() -> String {
+    std::env::var("HAUSKI_TEST_BASE_URL")
+        .ok()
+        .unwrap_or_else(|| "http://127.0.0.1:8080".to_string())
+}
+
+#[tokio::test]
+#[ignore] // nur on-demand ausführen
+async fn metrics_endpoint_exposes_prometheus_text() {
+    let url = format!("{}/metrics", base_url().trim_end_matches('/'));
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .send()
+        .await
+        .expect("request to /metrics failed");
+
+    assert_eq!(resp.status(), StatusCode::OK, "unexpected status for /metrics");
+
+    // Content-Type sollte Prometheus-Textformat sein
+    let ctype = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_lowercase();
+    assert!(
+        ctype.contains("text/plain"),
+        "unexpected content-type: {}",
+        ctype
+    );
+
+    let body = resp.text().await.expect("reading response body failed");
+    // Heuristik: Prometheus-Textformat enthält i. d. R. HELP/TYPE-Zeilen
+    assert!(
+        body.contains("# HELP") || body.contains("# TYPE"),
+        "unexpected /metrics payload (length={}): first bytes: {:?}",
+        body.len(),
+        &body.as_bytes().get(0..64)
+    );
+}
+

--- a/docs/adrs/ADR-0001-toolchain-strategy.md
+++ b/docs/adrs/ADR-0001-toolchain-strategy.md
@@ -1,0 +1,45 @@
+# ADR-0001: Einheitliche Toolchain-Strategie (Rust, Python, UV)
+
+**Status:** Accepted  
+**Datum:** 2025-10-23  
+**Autor:** hausKI Team
+
+## Kontext
+In der Vergangenheit drifteten Toolchain-Versionen zwischen lokaler Entwicklung, CI
+und DevContainer auseinander (Rust-Toolchain, Python, UV). Das führte zu
+unreproduzierbaren Builds und inkonsistenten Abhängigkeiten.
+
+## Entscheidung
+Wir führen eine zentrale, maschinenlesbare Datei ein (z. B. `toolchain.versions.yml`),
+aus der **CI-Workflows** und **DevContainer** ihre Versionen lesen. Ziel: keine
+hartcodierten Versionsangaben mehr an mehreren Stellen.
+
+Beispiel:
+```yaml
+rust: "stable"        # oder fix: "1.81.0"
+python: "3.12"
+uv: "0.7.0"
+```
+
+### CI
+- GitHub Actions lesen (bei Bedarf via `actions/github-script` oder einfachem `yq/jq`)
+  die Werte und setzen `RUST_TOOLCHAIN`, `PYTHON_VERSION`, `UV_VERSION`.
+- Fallback bleibt `stable`, falls Datei nicht existiert.
+
+### DevContainer/Local
+- DevContainer (oder `.wgx/profile.yml`/`pyproject.toml`) übernimmt die zentralen
+  Versionen und pinnt diese deterministisch.
+
+## Konsequenzen
+- **Pro:** Reproduzierbare Builds, weniger Aufwand bei Upgrades, einheitliche
+  Dokumentation.
+- **Contra:** Kleiner Initialaufwand zur Umstellung der Workflows und Container.
+
+## Alternativen
+- Versionsangaben weiterhin dezentral pflegen (verworfen wegen Drift-Risiko).
+
+## Folgearbeiten
+1. `toolchain.versions.yml` im Repo anlegen (Werte s. oben).
+2. CI-Workflows so anpassen, dass sie daraus lesen (ohne harte Defaults).
+3. DevContainer/`.wgx` an zentrale Datei koppeln.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,8 @@ nav:
       - Sprache: process/sprache.md
       - Tests & Qualität: process/testing.md
       - Release: process/release.md
+  - ADRs:
+      - Toolchain-Strategie: adrs/ADR-0001-toolchain-strategy.md
   - Runbooks:
       - Übersicht: runbooks/index.md
       - Lokale Entwicklung: runbooks/local-dev.md


### PR DESCRIPTION
## Summary
- add ADR documenting the unified toolchain versioning approach
- introduce an ignored `/metrics` integration smoke test for hauski-core
- link the toolchain ADR into the MkDocs navigation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f9c2fc9ee8832c88aeefe16eb5ebd6