### PR TITLE
Add caret message capture to rust problem matcher

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -14,8 +14,13 @@
           "file": 1,
           "line": 2,
           "column": 3
+        },
+        {
+          "regexp": "^\\s*\\|\\s*\\^\\s*(.*)$",
+          "message": 1
         }
-      ]
+      ],
+      "loop": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a caret-line pattern to the rust problem matcher so annotations retain the message text
- allow the matcher to loop through consecutive diagnostic lines for multi-line spans and notes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f9bbd45de8832c8d67c4a475585346