### PR TITLE
docs: reference toolchain adr in audit

### DIFF
--- a/docs/audit-hauski.md
+++ b/docs/audit-hauski.md
@@ -47,3 +47,30 @@ Dieses Dokument ergänzt die bestehende Analyse durch gezielte Empfehlungen zur 
 
 Diese Ergänzungen konsolidieren Toolchains, vereinheitlichen CI-Checks und
 verankern den hausKI-Review-Zyklus direkt in der CI/CD-Pipeline.
+
+
+---
+
+## 5. Verknüpfte Architekturentscheidungen
+
+Die vorliegende Audit-Erweiterung ist mit folgenden Architekturentscheidungen verknüpft:
+
+| ADR | Titel | Status | Bezug |
+|-----|--------|---------|--------|
+| [ADR-0001](adrs/ADR-0001-toolchain-strategy.md) | Einheitliche Toolchain-Strategie | `Accepted` | Definiert zentrale Toolchain-Versionen für CI und lokale Entwicklung |
+
+Diese Entscheidung dient als Basis für alle weiteren CI- und Container-Anpassungen.  
+Künftige ADRs (z. B. für Speicher- und Kommunikationsschichten) sollten diesem Schema folgen.
+
+## 6. Begleitender Smoke-Test
+
+Als technische Verprobung des CI-Health-Flows wurde ein minimaler Integrationstest
+unter `crates/core/tests/metrics_smoke.rs` hinzugefügt.  
+Dieser prüft die Verfügbarkeit von `/metrics` und dient als Ankerpunkt für
+spätere API-Tests (z. B. `/ask`, `/chat`, `/health`).
+
+Beispiel:
+```bash
+HAUSKI_TEST_BASE_URL="http://127.0.0.1:8080" \
+  cargo test -p hauski-core --test metrics_smoke -- --ignored --nocapture
+```


### PR DESCRIPTION
## Summary
- add a section linking the audit to ADR-0001 and highlighting its status
- document the supporting metrics smoke test with usage instructions
- format the ADR status value using inline code styling for consistent rendering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f9c33916e0832c84f3b397a0e427fa