### PR TITLE
Relax rustc problem matcher

### DIFF
--- a/.github/rust.json
+++ b/.github/rust.json
@@ -14,10 +14,6 @@
           "file": 1,
           "line": 2,
           "column": 3
-        },
-        {
-          "regexp": "^\\s*\\|\\s*\\^\\s*(.*)$",
-          "message": 1
         }
       ],
       "loop": true


### PR DESCRIPTION
## Summary
- remove the caret-only pattern from the rustc problem matcher so GitHub annotations accept snippet lines between message and caret

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f9e24bae74832c8a43b34ad51d9fc1