### PR TITLE
Add module and runbook documentation coverage

### DIFF
--- a/docs/audit-hauski.md
+++ b/docs/audit-hauski.md
@@ -74,3 +74,20 @@ Beispiel:
 HAUSKI_TEST_BASE_URL="http://127.0.0.1:8080" \
   cargo test -p hauski-core --test metrics_smoke -- --ignored --nocapture
 ```
+---
+
+## Weiterführende Runbooks
+
+Diese Audit-Ergebnisse sind praxisrelevant und stehen in direkter Verbindung zu den operativen
+Runbooks des hausKI-Ökosystems:
+
+| Runbook | Thema | Bezug |
+|----------|--------|--------|
+| [Upgrade-Guide](runbooks/upgrade-guide.md) | sicheres Aktualisieren von Toolchains, Vendor-Snapshots und Modellen | Umsetzung der Toolchain-Strategie (ADR-0001) |
+| [Incident-Response](runbooks/incident-response.md) | Diagnose und Wiederherstellung bei Laufzeitstörungen | Anwendung der Observability- und Policy-Budgets |
+
+Die Querverweise schließen den Audit-Kreislauf und verbinden Architektur, CI-Governance und Betrieb
+innerhalb des hausKI-Dokumentationssystems.
+
+**Letzte Erweiterung:** 2025-10-23 – Backlinks zu Runbooks ergänzt.
+

--- a/docs/modules/indexd.md
+++ b/docs/modules/indexd.md
@@ -1,0 +1,58 @@
+# Modul: indexd
+
+**Rolle:** Speicherung und semantische Suche  
+**Komponente:** `hauski-indexd` (Crate)
+
+---
+
+## Überblick
+
+`indexd` implementiert die Indexierungs- und Query-Schicht von hausKI.
+Zentral ist das **`VectorStore`-Trait**, das abstrakte Such- und Embedding-Backends erlaubt (z. B. *tantivy+hnsw* oder *Qdrant*).
+
+### Hauptaufgaben
+- Speichern von Dokument-Embeddings (Text, OS-Kontext, Memory-Snippets)
+- Durchführen semantischer Queries (Top-k, Score, Namespace-Filter)
+- Bereitstellen der Index-Metriken für `/metrics`
+
+---
+
+## Architektur
+
+| Komponente | Beschreibung |
+|-------------|--------------|
+| **Indexer** | wandelt Events/Texts in Embeddings um (via `semantAH`) |
+| **Store** | persistiert Embeddings (SQLite oder remote Vector-DB) |
+| **API** | REST-Endpunkte `/index`, `/query`, `/related` |
+
+---
+
+## Konfiguration
+
+```yaml
+index:
+  backend: "sqlite"
+  path: "~/.hauski/index.db"
+  embedding_model: "all-MiniLM-L6-v2"
+  max_k: 100
+```
+
+---
+
+## Metriken & Budgets
+
+- `index_queries_total`
+- `index_query_duration_seconds`  
+  *Budget:* p95 ≤ 60 ms  
+
+---
+
+## Offene Aufgaben
+
+- [ ] HNSW-Backend dokumentieren  
+- [ ] Beispiel-Querys ergänzen  
+- [ ] API-Spec per `utoipa` exportieren  
+
+---
+
+**Letzte Aktualisierung:** 2025-10-23

--- a/docs/modules/observability.md
+++ b/docs/modules/observability.md
@@ -1,0 +1,56 @@
+# Modul: Observability
+
+**Rolle:** Überwachung, Logging, Metriken, Tracing  
+**Verortung:** Querschnittsmodul (Core-Integration)
+
+---
+
+## Überblick
+
+Das Observability-Modul bündelt die Mess- und Diagnosepfade:
+
+- **Logs:** strukturiert via `tracing` + `tracing-subscriber`
+- **Metriken:** Prometheus-Exporter unter `/metrics`
+- **Tracing:** span-basiert mit korrelierbaren Request-IDs
+- **Budgets:** definierte SLOs in `policies/limits.yaml`
+
+---
+
+## Aufbau
+
+| Komponente | Zweck |
+|-------------|-------|
+| **Logger** | Ausgabe strukturierter Events (JSON/ANSI) |
+| **Exporter** | Prometheus-kompatibler HTTP-Endpoint |
+| **AppMetrics** | fasst Latenz, Fehler und Ressourcennutzung zusammen |
+
+---
+
+## Beispiel-Budgets
+
+```yaml
+latency:
+  llm_p95_ms: 400
+  index_p95_ms: 60
+thermal:
+  gpu_max_c: 80
+  power_watt_dgpu: 220
+```
+
+---
+
+## Troubleshooting
+
+- Prüfen: `curl -s localhost:8080/metrics | grep hauski`
+- Health-Check: `curl -s localhost:8080/health`
+- Log-Level erhöhen: `RUST_LOG=hauski=trace`
+
+---
+
+## Geplante Erweiterungen
+- [ ] OpenTelemetry-Exporter
+- [ ] Integration in `hauski-reviewd`
+
+---
+
+**Letzte Aktualisierung:** 2025-10-23

--- a/docs/modules/policy.md
+++ b/docs/modules/policy.md
@@ -1,0 +1,51 @@
+# Modul: Policy & Limits
+
+**Rolle:** Durchsetzung von Laufzeit- und Ressourcenrichtlinien  
+**Crate:** `hauski-policy`
+
+---
+
+## Überblick
+
+Das Policy-Modul definiert und überwacht **System-Budgets** für Performance,
+Thermik, LLM-Latenz und weitere Ressourcenparameter.  
+Es stellt eine gemeinsame Policy-Engine für hausKI-Komponenten bereit.
+
+---
+
+## Hauptaufgaben
+
+- Validieren von Konfigurationen gegen Policies  
+- Laufzeitprüfung (Budget-Überwachung)  
+- Bereitstellen strukturierter Policy-Events für `leitstand`  
+
+---
+
+## Beispielkonfiguration (`policies/limits.yaml`)
+
+```yaml
+latency:
+  llm_p95_ms: 400
+  index_p95_ms: 60
+thermal:
+  gpu_max_c: 80
+  power_watt_dgpu: 220
+asr:
+  wer_max: 0.10
+```
+
+---
+
+## Schnittstellen
+
+- `PolicySnapshot` – serialisierbarer Zustand  
+- `BudgetGuard` – automatisierte Prüfmechanik  
+- Export via `/policies` API  
+
+---
+
+## ToDo
+- [ ] Event-Schema in `contracts/` dokumentieren  
+- [ ] CLI-Integration `hauski-cli policy check` ergänzen  
+
+**Letzte Aktualisierung:** 2025-10-23

--- a/docs/runbooks/incident-response.md
+++ b/docs/runbooks/incident-response.md
@@ -1,0 +1,66 @@
+# Runbook: Incident-Response
+
+**Ziel:** Dieses Runbook beschreibt die Schritte zur Diagnose und Behandlung kritischer Störungen im hausKI-Stack.
+
+---
+
+## 1. Auslöser erkennen
+
+Typische Signale:
+
+- Prometheus-Alarm zu Latenz-Budgetverletzung (`latency_llm_p95_ms > 400`)
+- Health-Check `/health` liefert `503`
+- Crash-Loop oder nicht erreichbarer Port 8080
+- HausKI-Review-Daemon meldet „stalled“ Runs
+
+---
+
+## 2. Sofortmaßnahmen
+
+| Bereich | Prüfung | Kommando / Tool |
+|----------|----------|-----------------|
+| **Service-Status** | Läuft der Core-Prozess? | `ps aux | grep hauski-cli` |
+| **Healthcheck** | API verfügbar? | `curl -sf localhost:8080/health` |
+| **Metriken** | Exporte verfügbar? | `curl -sf localhost:8080/metrics | head` |
+| **Logs** | Fehlerquelle | `journalctl -u hauski.service -n 200` |
+
+> 🔧 **Hinweis:** In dev-Umgebungen kann mit `RUST_LOG=hauski=trace` temporär mehr Detailtiefe aktiviert werden.
+
+---
+
+## 3. Typische Ursachen
+
+- **Speicherlimit erreicht:** `index.db` oder `/tmp` voll → `du -sh ~/.hauski` prüfen.  
+- **GPU-Thermik:** `nvidia-smi` zeigt > 80 °C → Policy-Guard greift.  
+- **Policy-Violation:** Eintrag in `~/.hauski/review/index.json` → BudgetCheck-Failure.  
+- **Netzwerkblockade:** `egress`-Policy verhindert externen Aufruf.  
+
+---
+
+## 4. Wiederherstellung
+
+1. Dienst stoppen: `systemctl --user stop hauski`
+2. Logs sichern: `journalctl -u hauski.service > hauski-crash.log`
+3. Index ggf. komprimieren: `sqlite3 ~/.hauski/index.db VACUUM;`
+4. Dienst starten: `systemctl --user start hauski`
+
+---
+
+## 5. Nachbereitung
+
+- Review-Report erzeugen (`hauski review`)  
+- Incident im `leitstand` protokollieren  
+- ggf. ADR-Ergänzung oder Limit-Anpassung dokumentieren  
+
+---
+
+**Letzte Aktualisierung:** 2025-10-23
+
+---
+
+## Verknüpfte Dokumente
+
+- [Modul: Observability](../modules/observability.md) — beschreibt Metriken, Budgets und Health-Endpunkte  
+- [Audit-Bericht](../audit-hauski.md) — Überblick über CI-/Governance-Audits und Folgeempfehlungen  
+
+Diese Seite ist Teil des operativen Doku-Kreislaufs von **hausKI** (Runbooks ↔ Module ↔ Audit).

--- a/docs/runbooks/upgrade-guide.md
+++ b/docs/runbooks/upgrade-guide.md
@@ -1,0 +1,74 @@
+# Runbook: Upgrade-Guide
+
+**Ziel:** Sicheres Aktualisieren von hausKI, seinen Modulen und Modellen unter Beibehaltung der Offline-Fähigkeit.
+
+---
+
+## 1. Vorbereitung
+
+- Alle laufenden Dienste beenden (`systemctl --user stop hauski*`)  
+- Arbeitsverzeichnis sauber halten (`git status` → clean)  
+- Optional: Review-Snapshot sichern (`~/.hauski/review/<repo>/`)  
+
+---
+
+## 2. Toolchains prüfen
+
+```bash
+cat toolchain.versions.yml
+uv --version
+rustc --version
+```
+
+Wenn Versionen abweichen:
+```bash
+uv self update
+rustup self update
+rustup update stable
+```
+
+---
+
+## 3. Vendor-Snapshot erneuern
+
+```bash
+rm -rf vendor/
+cargo vendor --locked
+git add vendor/
+git commit -m "refresh vendor snapshot"
+```
+
+Damit bleiben Offline-Builds reproduzierbar.
+
+---
+
+## 4. Models & Seeds aktualisieren
+
+- **Ollama-Modelle:** `ollama pull all-MiniLM-L6-v2`  
+- **Whisper/Piper:** Download über `just ai-sync`  
+- **semantAH Seeds:** `uv run scripts/build_index.py`
+
+---
+
+## 5. Upgrade-Checkliste
+
+| Prüfschritt | Soll-Zustand |
+|--------------|--------------|
+| `cargo test --workspace` | ✅ alle grün |
+| `just lint` | ✅ keine Warnungen |
+| `/metrics` erreichbar | ✅ 200 OK |
+| `hauski review` erzeugt Report | ✅ Index aktualisiert |
+
+---
+
+**Letzte Aktualisierung:** 2025-10-23
+
+---
+
+## Verknüpfte Dokumente
+
+- [ADR-0001 Toolchain-Strategie](../adrs/ADR-0001-toolchain-strategy.md) — legt fest, wie Versionen zentral gepflegt werden  
+- [Audit-Bericht](../audit-hauski.md) — referenziert die Toolchain-Synchronisierung und CI-Empfehlungen  
+- [Runbook: Incident-Response](incident-response.md) — beschreibt, wie bei fehlerhaften Upgrades oder Policy-Verletzungen vorzugehen ist  
+
+Diese Seite ergänzt den strategischen Upgrade-Pfad und verbindet ADRs mit operativer Praxis.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,9 @@ nav:
       - Core: modules/core.md
       - Memory: modules/memory.md
       - Audio: modules/audio.md
+      - Indexd: modules/indexd.md
+      - Observability: modules/observability.md
+      - Policy: modules/policy.md
   - Prozesse:
       - Übersicht: process/README.md
       - Sprache: process/sprache.md
@@ -32,6 +35,8 @@ nav:
       - Lokale Entwicklung: runbooks/local-dev.md
       - semantAH Bootstrap: runbooks/semantah_local.md
       - Troubleshooting: runbooks/troubleshooting.md
+      - Incident-Response: runbooks/incident-response.md
+      - Upgrade-Guide: runbooks/upgrade-guide.md
   - semantAH: semantah.md
   - Audit: audit-hauski.md
 markdown_extensions:


### PR DESCRIPTION
## Summary
- add documentation pages for the indexd, observability, and policy modules
- introduce incident-response and upgrade-guide runbooks and cross-link them within the docs
- extend the audit report with backlinks and register the new pages in the MkDocs navigation
- clarify the rustup upgrade instructions in the upgrade runbook

## Testing
- ⚠️ `uv run mkdocs build --strict --clean` *(fails: network error while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68fa7ae97a7c832cab5dcca5e5c9145b