### PR TITLE
ci: inline change detection and release publishing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,17 @@ RUST_LOG=info,hauski=debug
 # Optional: lokaler Chat-Upstream (z. B. llama.cpp --server unter Port 8081)
 # Wird normalerweise in configs/flags.yaml gesetzt.
 # CHAT_UPSTREAM_URL=http://127.0.0.1:8081
+
+# Start-all Defaults (scripts/start-all.sh)
+# (Lege deine .env im Repo-Root an oder nutze configs/.env)
+# Pfad zu deinem GGUF-Modell (für llama.cpp --server)
+# MODEL="$HOME/models/your-model.gguf"
+# Standardport für llama.cpp --server
+# PORT=8081
+# (scripts/stop-all.sh nutzt diesen Wert, wenn kein Port-Argument übergeben wird.)
+# Explizite Upstream-URL (überschreibt Host/Port)
+# Externe URLs deaktivieren automatisch den lokalen llama.cpp-Start.
+# UPSTREAM_URL="http://127.0.0.1:8081"
+# tmux-/Upstream-Flags
+# USE_TMUX=1
+# NO_UPSTREAM=1

--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -20,7 +20,9 @@ jobs:
   tools:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
 
       - name: Install uv
         run: |
@@ -33,7 +35,7 @@ jobs:
           uv --version
 
       - name: Cache uv
-        uses: actions/cache@v4
+        uses: actions/cache@69b5f8c5e3a745449f6d753c868763ac08d5e4ab
         with:
           path: |
             ~/.cache/uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,23 +51,54 @@ jobs:
       docs:  ${{ steps.filter.outputs.docs }}
       sh:    ${{ steps.filter.outputs.sh }}
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
-      - uses: dorny/paths-filter@v3
+      - name: Detect changed paths
         id: filter
-        with:
-          filters: |
-            rust:
-              - '**/*.rs'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-            docs:
-              - '**/*.md'
-              - 'docs/**'
-            sh:
-              - '**/*.sh'
-              - '.github/workflows/**'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          base_branch="${BASE_REF:-main}"
+          git fetch --no-tags --depth=1 origin "$base_branch"
+          base_ref="origin/${base_branch}"
+          echo "Using base ref: ${base_ref}" >&2
+
+          rust=false
+          docs=false
+          sh=false
+
+          git diff --name-only "${base_ref}"...HEAD | while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            case "$file" in
+              *.rs|Cargo.toml|Cargo.lock)
+                rust=true
+                ;;
+            esac
+            case "$file" in
+              *.md|docs/*)
+                docs=true
+                ;;
+            esac
+            case "$file" in
+              *.sh|*.bash|.github/workflows/*)
+                sh=true
+                ;;
+            esac
+            if $rust && $docs && $sh; then
+              break
+            fi
+          done
+
+          {
+            printf 'rust=%s\n' "$rust"
+            printf 'docs=%s\n' "$docs"
+            printf 'sh=%s\n'   "$sh"
+          } >> "$GITHUB_OUTPUT"
 
   repo-lint:
     name: Repo — Markdown & Shell
@@ -87,26 +118,53 @@ jobs:
       RUSTFLAGS: -Dwarnings
     timeout-minutes: 12
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Enable Rust problem matchers
         run: echo "::add-matcher::.github/rust.json"
       - name: Show resolved toolchain
         run: echo "Using toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}"
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
           # Fall back to "stable" if the workflow-level environment variable is empty.
           toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@29f7d9a5c8d5a5ca45c8c7c3aa4642f3f7e87b94
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh
       - name: rustfmt (check)
         run: cargo fmt --all --check
       - name: clippy (deny warnings)
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  shellcheck:
+    name: Shell — lint scripts
+    needs: changes
+    if: >
+      (github.event_name == 'merge_group') ||
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.draft == false &&
+       (
+         needs.changes.outputs.sh == 'true' ||
+         contains(join(github.event.pull_request.labels.*.name), 'full-ci')
+       ))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
+        with:
+          ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: shellcheck
+        run: git ls-files '*.sh' '*.bash' | xargs -r shellcheck -x
 
   links:
     name: docs link check (lychee)
@@ -120,10 +178,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
-      - uses: lycheeverse/lychee-action@v2
+      - uses: lycheeverse/lychee-action@cc141a2dd1b94f572cca40a6e7d1c2255b21f621
         with:
           args: >-
             --no-progress
@@ -137,7 +197,7 @@ jobs:
             "**/*.md"
       - name: Upload lychee report (on failure)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@0b8b5fa3f19d6324db82a651c01fb9b31c764cb5
         with:
           name: lychee-report
           path: ./.lycheecache
@@ -157,19 +217,19 @@ jobs:
        ))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Emit TODO notice
-        run: |
-          sudo apt-get update && sudo apt-get install -y shellcheck
-          git ls-files '*.sh' | xargs -r shellcheck -x
+        run: echo "index budget gate placeholder"
       - name: Lychee (links)
         if: >-
           github.event_name == 'merge_group' ||
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci'))
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@cc141a2dd1b94f572cca40a6e7d1c2255b21f621
         with:
           args: --no-progress --verbose --retry-wait-time 2 --max-redirects 5 -- "**/*.md"
 
@@ -182,27 +242,29 @@ jobs:
     env:
       RUSTFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Enable Rust problem matchers
         run: echo "::add-matcher::.github/rust.json"
       - name: Show resolved toolchain
         run: echo "Using toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}"
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
           # Fall back to "stable" if the workflow-level environment variable is empty.
           toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@29f7d9a5c8d5a5ca45c8c7c3aa4642f3f7e87b94
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh
       - name: Cargo fmt
         run: cargo fmt --all -- --check
       - name: Cargo clippy
         run: cargo clippy --all-targets -- -D warnings
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@7a11182e3a1a996a96f2ef749398a422c9b6f4ff
         with:
           tool: nextest
       - name: Tests
@@ -214,7 +276,7 @@ jobs:
           fi
       - name: Upload target (on failure)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@0b8b5fa3f19d6324db82a651c01fb9b31c764cb5
         with:
           name: rust-check-target
           path: target
@@ -228,16 +290,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Show resolved toolchain
         run: echo "Using toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}"
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Fall back to "stable" if the workflow-level environment variable is empty.
           toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@29f7d9a5c8d5a5ca45c8c7c3aa4642f3f7e87b94
       - name: Build hauski-cli
         run: cargo build -p hauski-cli
       - name: Health smoke
@@ -261,19 +325,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Show resolved toolchain
         run: echo "Using toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}"
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
           # Fall back to "stable" if the workflow-level environment variable is empty.
           toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@7a11182e3a1a996a96f2ef749398a422c9b6f4ff
         with:
           tool: cargo-deny
       - name: cargo deny (advisories/bans/licenses)
@@ -281,4 +347,4 @@ jobs:
           cargo deny check advisories
           cargo deny check bans
           cargo deny check licenses
-      - uses: rustsec/audit-check@v2
+      - uses: rustsec/audit-check@618c2437de90585c33833719fdcddc50271940ad

--- a/.github/workflows/cli-docs-check.yml
+++ b/.github/workflows/cli-docs-check.yml
@@ -31,7 +31,8 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
 
       - name: Make generator executable (defensiv)
         run: |

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.draft == false }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
       - name: Enable Rust problem matchers
         run: echo "::add-matcher::.github/rust.json"
       - name: Quick checks
@@ -52,20 +54,30 @@ EOP
           head -n 1000 pr.diff >> prompt.md
           npx -y @openai/codex@1.0.0 < prompt.md > review.txt
       - name: Upload review as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@0b8b5fa3f19d6324db82a651c01fb9b31c764cb5
         with:
           name: codex-review-${{ github.run_id }}
           path: review.txt
           retention-days: 7
       - name: Comment on PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const body = fs.readFileSync('review.txt', 'utf8').slice(0, 60000);
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body
-            })
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          payload=$(python - <<'PY'
+import json
+from pathlib import Path
+
+body = Path('review.txt').read_text()[:60000]
+print(json.dumps({"body": body}))
+PY
+)
+          curl -fsSL \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -X POST \
+            "https://api.github.com/repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+            -d "$payload"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,8 +26,10 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
+      - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
           toolchain: stable
@@ -37,7 +39,7 @@ jobs:
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh
       - name: Cache cargo + target
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@29f7d9a5c8d5a5ca45c8c7c3aa4642f3f7e87b94
         with:
           cache-on-failure: true
           shared-key: ${{ runner.os }}-cov-${{ hashFiles('**/Cargo.lock') }}
@@ -53,7 +55,7 @@ jobs:
           cargo llvm-cov $PKGS --lcov --output-path lcov.info
       - name: Upload lcov
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@0b8b5fa3f19d6324db82a651c01fb9b31c764cb5
         with:
           name: lcov.info
           path: lcov.info

--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -38,14 +38,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
       - name: Enable Rust problem matchers
         run: echo "::add-matcher::.github/rust.json"
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
           toolchain: stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@29f7d9a5c8d5a5ca45c8c7c3aa4642f3f7e87b94
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh
       - name: Build (release)
@@ -97,7 +99,7 @@ jobs:
           echo "::notice::index search budget p95 target: 60ms (observability to be enforced later)"
       - name: Upload logs/artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@0b8b5fa3f19d6324db82a651c01fb9b31c764cb5
         with:
           name: hauski-heavy-artifacts
           path: |

--- a/.github/workflows/policy-ci.yml
+++ b/.github/workflows/policy-ci.yml
@@ -21,12 +21,14 @@ jobs:
     env:
       RUSTFLAGS: -Dwarnings
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
+      - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
           toolchain: stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@29f7d9a5c8d5a5ca45c8c7c3aa4642f3f7e87b94
         with:
           workspaces: .
       - name: Prepare lockfile (CI-only)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,10 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
+      - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
           toolchain: stable
@@ -48,9 +50,37 @@ jobs:
               (cd dist && shasum -a 256 * > "SHA256SUMS-${tag}-${suffix}.txt")
             fi
           fi
-      - uses: softprops/action-gh-release@v2
-        with:
-          files: dist/*
-          generate_release_notes: true
+      - name: Publish release artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ ! -d dist ]; then
+            echo "No dist directory found; skipping release upload." >&2
+            exit 0
+          fi
+
+          shopt -s nullglob
+          assets=(dist/*)
+          shopt -u nullglob
+
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "No artifacts to upload." >&2
+            exit 0
+          fi
+
+          tag="${GITHUB_REF_NAME:-}"
+          if [ -z "$tag" ]; then
+            tag="${GITHUB_REF##*/}"
+          fi
+          if [ -z "$tag" ]; then
+            echo "Unable to determine release tag" >&2
+            exit 1
+          fi
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" "${assets[@]}" --clobber
+          else
+            gh release create "$tag" "${assets[@]}" --generate-notes
+          fi

--- a/.github/workflows/reusable-validate-vendor.yml
+++ b/.github/workflows/reusable-validate-vendor.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Check vendor snapshot

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,8 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
+      - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
           toolchain: stable
@@ -61,8 +63,10 @@ jobs:
     timeout-minutes: 10
     needs: [deny]
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
+      - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
           toolchain: stable

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -16,8 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
+      - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
           toolchain: stable
@@ -28,7 +30,7 @@ jobs:
       - name: Pack vendor snapshot
         run: tar --zstd -cvf hauski-vendor-snapshot.tar.zst vendor
       - name: Upload vendor artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@0b8b5fa3f19d6324db82a651c01fb9b31c764cb5
         with:
           name: hauski-vendor-snapshot
           path: hauski-vendor-snapshot.tar.zst

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -22,7 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout repository
+        # Commit pin (matches v4 release) to prevent tag drift and ensure reproducibility
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a96968112b
 
       - name: Check .wgx/profile.yml presence
         run: |
@@ -30,7 +32,7 @@ jobs:
           echo "found .wgx/profile.yml"
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@64d81c650b05e6446f8aeaf6bb2e2eca1e2ef3dc
         with:
           python-version: '3.12'
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,12 +12,16 @@ __pycache__/
 
 # Logs and misc
 .env
+configs/.env
 .direnv/
 **/*.log
 *.log
 .DS_Store
 .coverage
 coverage.xml
+
+# Modelle (lokal gehalten)
+models/
 
 # Project specific
 .wgx/profile.local.yml

--- a/README.md
+++ b/README.md
@@ -11,6 +11,33 @@ HausKI ist ein lokaler KI-Orchestrator für Pop!_OS-Workstations mit NVIDIA-RTX-
 - **GPU-Unterstützung**: Optimiert für NVIDIA-GPUs zur Beschleunigung von KI-Inferenz-Aufgaben.
 - **Vektorsuche**: Integrierte Vektorsuche mit `tantivy` und `SQLite` zur effizienten Verarbeitung von Wissen.
 - **Policy-Engine**: Ein regelbasiertes System zur Steuerung von Routing, Speicher und Systemgrenzen.
+
+### Lokaler Chat (llama.cpp Upstream)
+
+**Voraussetzungen:**
+- `tmux` (für parallele Upstream-/Core-Sitzung)
+- `lsof` (für das Stop-Skript)
+- Optional: `just` (verkürzt Startaufrufe)
+
+Für einen lokalen, OpenAI-kompatiblen Chat-Pfad nutze das Runbook unter  
+`docs/runbooks/local-chat.md` **oder** starte alles per:
+
+```bash
+scripts/start-all.sh --model "$HOME/models/your-model.gguf" --port 8081
+```
+
+**Extras**:
+- `--tmux` startet eine Session `hauski` (Fenster: `upstream`, `core`) – ideal zum Debuggen.
+- `.env`/`configs/.env` erlauben Start ohne Flags (siehe `.env.example`).
+- `--upstream-url` oder `UPSTREAM_URL=…` verbindet gegen einen bestehenden Dienst; externe URLs deaktivieren den lokalen Start automatisch (optional mit `--no-upstream` erzwingbar).
+- Schreibt eine Flags-Datei (unter `~/.config/hauski/hauski-flags.yaml`) und setzt `HAUSKI_FLAGS` automatisch auf `chat_upstream_url` (bestehende `HAUSKI_FLAGS`-Werte werden weiterverwendet).
+- Logs inkl. einfacher Rotation unter `~/.local/state/hauski/logs/`.
+- Stoppen mit:
+
+```bash
+scripts/stop-all.sh        # nutzt tmux, sonst Ports/PIDs
+```
+
 ---
 
 ## Inhalt

--- a/docs/runbooks/local-chat.md
+++ b/docs/runbooks/local-chat.md
@@ -1,0 +1,105 @@
+# Lokaler Chat mit HausKI (llama.cpp Upstream)
+
+Ziel: HausKI lokal „sprechfähig“ machen, indem `/v1/chat` an einen OpenAI-kompatiblen **llama.cpp**-Server proxied wird.
+
+**Neu:** tmux-Start, `.env`-Variablen, Logs mit einfacher Rotation, Stop-Script.
+
+## Voraussetzungen
+
+- Ein lokales GGUF-Modell (z. B. in `~/models/your-model.gguf`)
+- Optional: ein `llama.cpp`-Server-Binary (oder via `just llama-server`, falls vorhanden)
+- HausKI Core lauffähig (`cargo build` bzw. `just run-core`)
+- **System-Tools:**
+  - `tmux` (parallele Fenster für Upstream & Core)
+  - `lsof` (für Prozess-Stop via `stop-all.sh`)
+  - Optional: `just` (Task-Runner für Kurzaufrufe)
+
+## Schnellstart: Ein-Kommando-Variante
+
+```bash
+scripts/start-all.sh \
+  --model "$HOME/models/your-model.gguf" \
+  --port 8081
+  # Optional:
+  # --tmux                 # startet Upstream & Core in einer tmux-Session "hauski"
+  # --no-upstream          # startet nur Core (wenn externer Upstream schon läuft)
+  # --upstream-url URL     # überschreibt Host/Port; externe URLs überspringen den lokalen Start automatisch
+```
+
+Das Skript:
+1. startet (falls verfügbar) den `llama.cpp`-Server auf Port 8081,
+2. schreibt eine Flags-Datei mit `chat_upstream_url=http://127.0.0.1:8081` unter `~/.config/hauski/hauski-flags.yaml` und setzt `HAUSKI_FLAGS` darauf,
+   > Wenn `HAUSKI_FLAGS` bereits gesetzt ist (z. B. auf eine eigene YAML), bleibt der bestehende Pfad unverändert.
+3. startet anschließend den HausKI-Core.
+
+### Start über `.env`
+Lege im Repo-Root eine `.env` (oder `configs/.env`) an (siehe `.env.example`):
+
+```
+MODEL="$HOME/models/your-model.gguf"
+PORT=8081
+# Optional:
+# UPSTREAM_URL="http://127.0.0.1:8081"
+# USE_TMUX=1
+# NO_UPSTREAM=1
+```
+
+Dann reicht: `scripts/start-all.sh --tmux`
+
+> Wenn kein passendes `llama`-Binary gefunden wird, gibt das Skript einen klaren Hinweis mit Beispielbefehlen aus.
+
+## Manuell (Einzelschritte)
+
+1. **llama.cpp-Server** (Beispiel):
+   ```bash
+   llama-server \
+     --port 8081 \
+     --model "$HOME/models/your-model.gguf" \
+     --ctx-size 4096 \
+     --batch-size 512
+   ```
+
+2. **HausKI-Core**:
+   - Entweder per `just run-core`
+   - Oder direkt: `cargo run -p hauski-cli -- serve`
+
+3. **Testaufruf**:
+   ```bash
+   curl -s -X POST http://127.0.0.1:8080/v1/chat \
+     -H 'Content-Type: application/json' \
+     -d '{"messages":[{"role":"user","content":"Hallo HausKI – hörst du mich?"}]}'
+   ```
+
+   - **501 Not Implemented**: Upstream nicht erreichbar → prüfe, ob `llama.cpp` auf Port 8081 läuft.
+   - **200 OK + Antwort**: Alles gut.
+
+## Konfiguration
+
+- Der Upstream lässt sich über `configs/flags.yaml` setzen:
+  ```yaml
+  chat_upstream_url: "http://127.0.0.1:8081"
+  ```
+  (Das Startskript legt dafür die Datei `~/.config/hauski/hauski-flags.yaml` an und setzt `HAUSKI_FLAGS` auf diesen Pfad.)
+
+## Tipps
+
+- **Modelle**: Wähle ein kleines bis mittleres GGUF-Modell für den Anfang (z. B. 7-13B-Klasse).
+- **Stabilität**: Starte `llama.cpp` zuerst, warte kurz, dann den Core. Mit `--no-upstream` (oder einer externen `--upstream-url`) überspringt das Skript den lokalen Start (und das Port-Waiting).
+- **Fehlersuche**: Logs prüfen (Terminal-Ausgabe von `llama-server` und HausKI-Core).
+
+## Logs & Stoppen
+
+- Logs landen standardmäßig unter `~/.local/state/hauski/logs/`:
+  - `upstream.log`, `core.log` (Rotation: `.1`, `.2` bei >5 MB)
+- Prozesse sauber beenden:
+  ```bash
+  scripts/stop-all.sh
+  ```
+  - Bei `--tmux`: tmux-Session `hauski` wird beendet.
+  - Ohne tmux: laufende PIDs (falls bekannt) werden beendet, ansonsten Ports geprüft (Port aus Argument **oder** `.env` → `PORT`).
+
+---
+
+**Essenz:** HausKI redet lokal, wenn ein OpenAI-kompatibler Upstream (llama.cpp) auf `127.0.0.1:8081` bereitsteht – Startskript erledigt die Orchestrierung.
+
+**∆-Radar:** Dieser Runbook-Eintrag führt eine klarere Start-Choreografie ein (Upstream→Core) und reduziert ad-hoc-Kommandos.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
   - Runbooks:
       - Übersicht: runbooks/index.md
       - Lokale Entwicklung: runbooks/local-dev.md
+      - Lokaler Chat: runbooks/local-chat.md
       - semantAH Bootstrap: runbooks/semantah_local.md
       - Troubleshooting: runbooks/troubleshooting.md
       - Incident-Response: runbooks/incident-response.md

--- a/scripts/lib/logging.bash
+++ b/scripts/lib/logging.bash
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Einfaches Logging + Mini-Rotation (bis 2 Backups) bei > 5 MB
+# Usage:
+#   source scripts/lib/logging.bash
+#   init_logs                      # setzt LOG_DIR
+#   rotate_log "$LOG_DIR/core.log"
+#   run_with_log "cmd ..." "$LOG_DIR/core.log"
+
+LOG_DIR_DEFAULT="${HOME}/.local/state/hauski/logs"
+MAX_SIZE=$((5*1024*1024)) # 5 MB
+
+init_logs() {
+  LOG_DIR="${LOG_DIR_DEFAULT}"
+  mkdir -p "${LOG_DIR}"
+  export LOG_DIR
+}
+
+rotate_log() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+  local size
+  size=$(wc -c < "$file" || echo 0)
+  if (( size > MAX_SIZE )); then
+    # shift: .1 -> .2
+    [[ -f "${file}.1" ]] && mv -f "${file}.1" "${file}.2" || true
+    mv -f "${file}" "${file}.1"
+    : > "$file"
+  fi
+}
+
+run_with_log() {
+  local cmd="$1"
+  local logfile="$2"
+  rotate_log "$logfile"
+  bash -lc "$cmd" >>"$logfile" 2>&1 &
+  echo $!
+}

--- a/scripts/start-all.sh
+++ b/scripts/start-all.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start: (1) Upstream (llama.cpp --server) (optional) + (2) HausKI Core
+# Features:
+#   - OpenAI-kompatibler Upstream (PORT, MODEL, --upstream-url)
+#   - tmux-Start (--tmux) mit Session "hauski"
+#   - .env-Unterstützung (.env oder configs/.env)
+#   - Logs (~/.local/state/hauski/logs) mit einfacher Rotation
+#   - HAUSKI_FLAGS: chat_upstream_url wird automatisch gesetzt
+#   - --no-upstream überspringt den lokalen llama.cpp-Start
+# Usage:
+#   scripts/start-all.sh --model ~/models/model.gguf [--port 8081]
+#                        [--upstream-url http://host:port] [--tmux]
+#                        [--no-upstream]
+
+MODEL="${MODEL:-}"
+PORT="${PORT:-8081}"
+UPSTREAM_URL="${UPSTREAM_URL:-}"
+USE_TMUX="${USE_TMUX:-0}"
+NO_UPSTREAM="${NO_UPSTREAM:-0}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${ROOT}"
+
+LLAMA_PID=""
+
+cleanup() {
+  local exit_code="${1:-0}"
+  if [[ -n "${LLAMA_PID}" ]]; then
+    if kill -0 "${LLAMA_PID}" 2>/dev/null; then
+      echo "⏹ Down: llama-server (${LLAMA_PID})"
+      kill -TERM "${LLAMA_PID}" 2>/dev/null || true
+      if sleep 2 && kill -0 "${LLAMA_PID}" 2>/dev/null; then
+        echo "• Erzwinge Beenden von llama-server (${LLAMA_PID})"
+        kill -KILL "${LLAMA_PID}" 2>/dev/null || true
+      fi
+      wait "${LLAMA_PID}" 2>/dev/null || true
+    fi
+  fi
+  return "${exit_code}"
+}
+
+cleanup_and_exit() {
+  local exit_code="${1:-0}"
+  cleanup "${exit_code}"
+  exit "${exit_code}"
+}
+
+trap 'cleanup $?' EXIT
+trap 'cleanup_and_exit 130' INT
+trap 'cleanup_and_exit 143' TERM
+
+# .env laden (falls vorhanden)
+load_env() {
+  local loaded=0
+  if [[ -f "${ROOT}/.env" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "${ROOT}/.env"
+    set +a
+    loaded=1
+  fi
+  if [[ -f "${ROOT}/configs/.env" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "${ROOT}/configs/.env"
+    set +a
+    loaded=1
+  fi
+  if [[ "$loaded" -eq 1 ]]; then
+    echo "• .env geladen"
+  fi
+}
+
+load_env
+MODEL="${MODEL:-}"
+PORT="${PORT:-8081}"
+UPSTREAM_URL="${UPSTREAM_URL:-}"
+USE_TMUX="${USE_TMUX:-0}"
+NO_UPSTREAM="${NO_UPSTREAM:-0}"
+
+normalize_bool() {
+  local raw="${1:-0}"
+  case "${raw}" in
+    1|true|TRUE|True|yes|YES|Yes|on|ON|On)
+      echo "1"
+      ;;
+    *)
+      echo "0"
+      ;;
+  esac
+}
+
+USE_TMUX="$(normalize_bool "${USE_TMUX}")"
+NO_UPSTREAM="$(normalize_bool "${NO_UPSTREAM}")"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model) MODEL="${2:-}"; shift 2 ;;
+    --port) PORT="${2:-}"; shift 2 ;;
+    --upstream-url) UPSTREAM_URL="${2:-}"; shift 2 ;;
+    --tmux) USE_TMUX="1"; shift ;;
+    --no-upstream) NO_UPSTREAM="1"; shift ;;
+    -h|--help)
+      sed -n '3,/^$/p' "$0" | sed 's/^#\s\{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unbekannte Option: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+source scripts/lib/logging.bash
+init_logs
+UPSTREAM_LOG="${LOG_DIR}/upstream.log"
+CORE_LOG="${LOG_DIR}/core.log"
+CONFIG_DIR="${XDG_CONFIG_HOME:-${HOME}/.config}/hauski"
+mkdir -p "${CONFIG_DIR}"
+
+DEFAULT_UPSTREAM_URL="http://127.0.0.1:${PORT}"
+UPSTREAM_URL_RAW="${UPSTREAM_URL}"
+
+if [[ -n "${UPSTREAM_URL}" && "${UPSTREAM_URL}" != "${DEFAULT_UPSTREAM_URL}" && "${NO_UPSTREAM}" = "0" ]]; then
+  echo "ℹ️  Externe Upstream-URL erkannt – überspringe lokalen llama.cpp-Start. Nutze --no-upstream explizit, um das Verhalten festzulegen."
+  NO_UPSTREAM="1"
+fi
+
+if [[ -z "${UPSTREAM_URL}" ]]; then
+  UPSTREAM_URL="${DEFAULT_UPSTREAM_URL}"
+fi
+
+if [[ "${NO_UPSTREAM}" = "1" && -z "${UPSTREAM_URL_RAW}" ]]; then
+  echo "⚠️  --no-upstream ohne --upstream-url – nutze ${UPSTREAM_URL}."
+fi
+
+if [[ "${NO_UPSTREAM}" = "1" ]]; then
+  echo "⏭️  Lokaler Upstream-Start übersprungen – verwende Upstream ${UPSTREAM_URL}."
+fi
+
+if [[ -z "${MODEL}" && "${NO_UPSTREAM}" = "0" ]]; then
+  echo "Fehler: --model <pfad/zum/model.gguf> ist erforderlich (oder --no-upstream setzen)." >&2
+  exit 2
+fi
+
+join_cmd() {
+  local -a parts=("$@")
+  local joined=""
+  local element
+  for element in "${parts[@]}"; do
+    joined+="$(printf '%q' "${element}") "
+  done
+  printf '%s' "${joined% }"
+}
+
+LLAMA_CMD=("llama-server" "--port" "${PORT}" "--model" "${MODEL}" "--ctx-size" "4096" "--batch-size" "512")
+CORE_CMD=("just" "run-core")
+if ! (command -v just >/dev/null 2>&1 && just --list 2>/dev/null | grep -qE '^\s*run-core\b'); then
+  CORE_CMD=("cargo" "run" "-p" "hauski-cli" "--" "serve")
+fi
+
+rotate_log "${CORE_LOG}"
+if [[ "${NO_UPSTREAM}" = "0" ]]; then
+  rotate_log "${UPSTREAM_LOG}"
+fi
+
+if [[ -z "${HAUSKI_FLAGS-}" ]]; then
+  HAUSKI_FLAGS="${CONFIG_DIR}/hauski-flags.yaml"
+  old_umask=$(umask)
+  umask 077
+  printf 'chat_upstream_url: "%s"\n' "${UPSTREAM_URL}" >"${HAUSKI_FLAGS}"
+  umask "${old_umask}"
+  export HAUSKI_FLAGS
+  echo "• HAUSKI_FLAGS Datei geschrieben: ${HAUSKI_FLAGS}"
+else
+  echo "• Nutze bestehendes HAUSKI_FLAGS=${HAUSKI_FLAGS}"
+fi
+
+echo "▶ Starte HausKI-Core mit HAUSKI_FLAGS='${HAUSKI_FLAGS}' …"
+
+if [[ "${USE_TMUX}" = "1" ]]; then
+  if ! command -v tmux >/dev/null 2>&1; then
+    echo "tmux nicht gefunden. Installiere tmux oder lasse --tmux weg."
+    exit 2
+  fi
+  echo "▶ Starte tmux-Session 'hauski' …"
+  tmux kill-session -t hauski >/dev/null 2>&1 || true
+  tmux new-session -d -s hauski
+  tmux set-environment -t hauski HAUSKI_FLAGS "${HAUSKI_FLAGS}" >/dev/null 2>&1 || true
+  if [[ "${NO_UPSTREAM}" = "0" ]]; then
+    tmux rename-window -t hauski:1 'upstream'
+    tmux send-keys -t hauski:upstream "$(join_cmd "${LLAMA_CMD[@]}") | tee -a $(printf '%q' "${UPSTREAM_LOG}")" C-m
+    tmux new-window -t hauski -n 'core'
+  else
+    tmux rename-window -t hauski:1 'core'
+  fi
+else
+  echo "▶ Upstream (llama.cpp) prüfen…"
+  if [[ "${NO_UPSTREAM}" = "0" ]]; then
+    if command -v llama-server >/dev/null 2>&1; then
+      echo "• llama-server gefunden: $(command -v llama-server)"
+      "${LLAMA_CMD[@]}" >>"${UPSTREAM_LOG}" 2>&1 &
+      LLAMA_PID=$!
+    else
+      echo "⚠️  Kein 'llama-server' im PATH gefunden."
+      echo "   Starte den Upstream bitte separat, z. B.:"
+      echo "     llama-server --port ${PORT} --model '${MODEL}' --ctx-size 4096 --batch-size 512"
+      echo "   oder (falls definiert):"
+      echo "     just llama-server MODEL='${MODEL}' PORT='${PORT}'"
+    fi
+  fi
+fi
+
+wait_for_upstream() {
+  local attempt
+  for attempt in {1..30}; do
+    if bash -lc "exec 3<>/dev/tcp/127.0.0.1/${PORT}" 2>/dev/null; then
+      echo "✓ Upstream erreichbar auf 127.0.0.1:${PORT}"
+      return 0
+    fi
+    sleep 0.3
+  done
+
+  echo "⚠️  Upstream auf Port ${PORT} nach 30 Versuchen nicht erreichbar." >&2
+  return 1
+}
+
+if [[ "${NO_UPSTREAM}" = "0" ]]; then
+  echo "⏳ Warte kurz, bis Port ${PORT} lauscht…"
+  wait_for_upstream || true
+fi
+
+if [[ "${USE_TMUX}" = "1" ]]; then
+  tmux send-keys -t hauski:core "$(join_cmd "${CORE_CMD[@]}") | tee -a $(printf '%q' "${CORE_LOG}")" C-m
+  echo "tmux läuft. Attach mit: tmux attach -t hauski"
+else
+  (cd "${ROOT}" && "${CORE_CMD[@]}") >>"${CORE_LOG}" 2>&1
+fi

--- a/scripts/stop-all.sh
+++ b/scripts/stop-all.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stoppt laufende Upstream/Core-Prozesse.
+# - Wenn tmux-Session 'hauski' existiert, wird sie beendet.
+# - Sonst werden Prozesse über bekannte PIDs/Ports gesucht und beendet.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${ROOT}"
+
+load_env() {
+  local loaded=0
+  if [[ -f "${ROOT}/.env" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "${ROOT}/.env"
+    set +a
+    loaded=1
+  fi
+  if [[ -f "${ROOT}/configs/.env" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "${ROOT}/configs/.env"
+    set +a
+    loaded=1
+  fi
+  if [[ "${loaded}" -eq 1 ]]; then
+    echo "• .env geladen"
+  fi
+}
+
+load_env
+
+SESSION="hauski"
+
+ARG_PORT="${1:-}"
+ENV_PORT="${PORT-}"
+
+if [[ -n "${ARG_PORT}" ]]; then
+  PORT="${ARG_PORT}"
+  PORT_SOURCE="Argument"
+elif [[ -n "${ENV_PORT}" ]]; then
+  PORT="${ENV_PORT}"
+  PORT_SOURCE=".env"
+else
+  PORT="8081"
+  PORT_SOURCE="Default"
+fi
+
+echo "• Verwende Port ${PORT} (${PORT_SOURCE})"
+
+if command -v tmux >/dev/null 2>&1 && tmux has-session -t "${SESSION}" 2>/dev/null; then
+  echo "⏹ tmux-Session '${SESSION}' wird beendet …"
+  tmux kill-session -t "${SESSION}"
+  exit 0
+fi
+
+echo "⏹ Versuche Prozesse ohne tmux zu beenden …"
+# Versuche: Upstream auf PORT
+if command -v lsof >/dev/null 2>&1; then
+  PIDS=$(lsof -tiTCP:"${PORT}" -sTCP:LISTEN || true)
+  if [[ -n "${PIDS:-}" ]]; then
+    echo "• beende Upstream PIDs auf Port ${PORT}: ${PIDS}"
+    kill -TERM ${PIDS} 2>/dev/null || true
+    sleep 1
+    if kill -0 ${PIDS} 2>/dev/null; then
+      echo "• Erzwinge Upstream-Kill (${PIDS})"
+      kill -KILL ${PIDS} 2>/dev/null || true
+    fi
+  fi
+else
+  echo "Hinweis: 'lsof' nicht gefunden – versuche pgrep-Fallback." >&2
+  PIDS=$(pgrep -f "llama-server.*--port[= ]${PORT}" || pgrep -f "llama-server" || true)
+  if [[ -n "${PIDS:-}" ]]; then
+    echo "• beende gefundene 'llama-server'-Prozesse: ${PIDS}"
+    kill -TERM ${PIDS} 2>/dev/null || true
+    sleep 1
+    if kill -0 ${PIDS} 2>/dev/null; then
+      echo "• Erzwinge Upstream-Kill (${PIDS})"
+      kill -KILL ${PIDS} 2>/dev/null || true
+    fi
+  fi
+fi
+
+# Optional: hauski-core Prozesse (heuristisch)
+pids_core=$(pgrep -f "hauski-cli.*serve" || true)
+if [[ -n "${pids_core}" ]]; then
+  echo "• beende hauski-core PIDs: ${pids_core}"
+  kill -TERM ${pids_core} 2>/dev/null || true
+  sleep 1
+  if kill -0 ${pids_core} 2>/dev/null; then
+    echo "• Erzwinge hauski-core-Kill (${pids_core})"
+    kill -KILL ${pids_core} 2>/dev/null || true
+  fi
+fi
+
+echo "✓ Stop versucht. Prüfe ggf. mit: ps aux | egrep '(llama-server|hauski-cli)'"


### PR DESCRIPTION
## Summary
- replace the dorny/paths-filter dependency with a first-party diff step so change detection remains deterministic without external actions
- swap the github-script and softprops release actions for shell-based curl/gh flows to keep the workflow free of unpinned third-party dependencies

## Testing
- bash scripts/start-all.sh --help
- bash scripts/stop-all.sh

------
https://chatgpt.com/codex/tasks/task_e_68fe4678781c832cbed03d02b94baff7