### PR TITLE
Pin actions/checkout to v4.1.6

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
 
       - name: Install uv
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
       sh:    ${{ steps.filter.outputs.sh }}
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Detect changed paths
@@ -124,8 +124,8 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Enable Rust problem matchers
@@ -162,8 +162,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Install shellcheck
@@ -189,8 +189,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - uses: lycheeverse/lychee-action@cc141a2dd1b94f572cca40a6e7d1c2255b21f621
@@ -228,8 +228,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Emit TODO notice
@@ -258,8 +258,8 @@ jobs:
       RUSTFLAGS: -Dwarnings
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Enable Rust problem matchers
@@ -311,8 +311,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Show resolved toolchain
@@ -346,8 +346,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.sha }}
       - name: Show resolved toolchain

--- a/.github/workflows/cli-docs-check.yml
+++ b/.github/workflows/cli-docs-check.yml
@@ -31,8 +31,8 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
 
       - name: Make generator executable (defensiv)
         run: |

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -16,8 +16,8 @@ jobs:
     if: ${{ github.event.pull_request.draft == false }}
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
       - name: Enable Rust problem matchers
         run: echo "::add-matcher::.github/rust.json"
       - name: Quick checks

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,8 +27,8 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
       - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.

--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -42,8 +42,8 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
       - name: Enable Rust problem matchers
         run: echo "::add-matcher::.github/rust.json"
       - name: Install jq

--- a/.github/workflows/policy-ci.yml
+++ b/.github/workflows/policy-ci.yml
@@ -22,8 +22,8 @@ jobs:
       RUSTFLAGS: -Dwarnings
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
       - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
       - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.

--- a/.github/workflows/reusable-validate-vendor.yml
+++ b/.github/workflows/reusable-validate-vendor.yml
@@ -13,8 +13,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Check vendor snapshot

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,8 +35,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
       - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.
@@ -64,8 +64,8 @@ jobs:
     needs: [deny]
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
       - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.

--- a/.github/workflows/vendor.yml
+++ b/.github/workflows/vendor.yml
@@ -20,8 +20,8 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
       - uses: dtolnay/rust-toolchain@3dc12f6bf0c8abca9015ae04963144c46cf9d9b5 # stable snapshot
         with:
           # Explicit input required by dtolnay/rust-toolchain to avoid setup failures.

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -23,8 +23,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        # Use stable v4 tag to ensure checkout availability
-        uses: actions/checkout@v4
+        # Pin to fixed v4.1.6 release to keep builds deterministic
+        uses: actions/checkout@v4.1.6
 
       - name: Check .wgx/profile.yml presence
         run: |


### PR DESCRIPTION
## Summary
- pin all GitHub Actions workflows to actions/checkout@v4.1.6 to avoid mutable tags

## Testing
- not run (CI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fea03c0454832cab293dc0afb615a6