### PR TITLE
Update GitHub Actions to stable tags

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -40,7 +40,7 @@ jobs:
         run: uv --version
 
       - name: Cache uv
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/uv

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -32,9 +32,11 @@ jobs:
           echo "found .wgx/profile.yml"
 
       - name: Setup Python
-        uses: actions/setup-python@64d81c650b05e6446f8aeaf6bb2e2eca1e2ef3dc
+        uses: actions/setup-python@v4
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
 
       - name: Install PyYAML
         run: |


### PR DESCRIPTION
## Summary
- switch the CI tools workflow cache step to use the stable v4 tag
- update the wgx-guard workflow to use the stable v4 tag for setup-python
- enable the built-in pip cache for the wgx-guard Python setup step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff30d0d9b0832caec7ff7233653f9c