### PR TITLE
Harden uv bootstrap in wgx guard

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -68,11 +68,18 @@ jobs:
       - name: (Optional) UV bootstrap (pyproject present)
         if: ${{ hashFiles('pyproject.toml') != '' }}
         run: |
+          set -euo pipefail
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          uv self update 0.1.44
-          uv --version
+          # Pin auf 0.7.x entsprechend .wgx/profile.yml
+          uv self update 0.7.*
+          ver="$(uv --version || true)"
+          echo "uv version: $ver"
+          case "$ver" in
+            "uv 0.7."*) : ;;  # ok
+            *) echo "::error::uv 0.7.x erwartet, gefunden: $ver"; exit 1 ;;
+          esac
           uv sync --frozen
 
       - name: Done

--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -10,7 +10,8 @@ env_priority:
 
 # Toolchain expectations for this repository.
 tooling:
-  uv: "0.7.x"
+  uv:
+    version: "0.7.x"
   python:
     version: "3.12"
     uv: true


### PR DESCRIPTION
## Summary
- add shell safety flags to the uv bootstrap step in the guard workflow
- pin uv self-update to the 0.7.x line and fail fast if a different release is installed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff3bc5d474832cbc187e66f8a1d46b