### PR TITLE
Clamp Ask limit range and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ HausKI bringt mit [semantAH](docs/semantah.md) eine semantische Gedächtnisschic
 curl -s "http://localhost:8080/ask?q=dein+text&k=5&ns=default" | jq
 ```
 
-Der Endpoint liefert die Top-k-Treffer mit Score, Snippet und Metadaten aus dem lokalen Index. Der Server begrenzt `k` serverseitig auf maximal 100 Treffer.
+Der Endpoint liefert die Top-k-Treffer mit Score, Snippet und Metadaten aus dem lokalen Index. Der Server begrenzt `k` serverseitig auf den Bereich 1–100 Treffer und spiegelt das effektive Limit im Response-Feld `k` wider.
 
 ---
 

--- a/docs/modules/core.md
+++ b/docs/modules/core.md
@@ -29,7 +29,7 @@ Der `core`-Dienst bildet die öffentliche HTTP/API-Schicht von HausKI. Er verbin
 | `/healthz` | GET | Lightweight-Probe für Load-Balancer. |
 | `/ready` | GET | Readiness; aktiv nach erfolgreichem Boot. |
 | `/metrics` | GET | Prometheus-Metriken inkl. HTTP-Zählern und Histogrammen. |
-| `/ask` | GET | Beispiel-Endpoint für orchestrierte Anfragen (Ask-Flow). |
+| `/ask` | GET | Beispiel-Endpoint für orchestrierte Anfragen (Ask-Flow, k wird auf 1–100 gedeckelt und im Response reflektiert). |
 | `/v1/chat` | POST | Chat-Stub (Antwort: `501 Not Implemented`, JSON-Schema sichtbar). |
 | `/index/upsert` | POST | Dokument-Chunks registrieren (weitergereicht an `indexd`, leere/fehlende Namespaces → `default`). |
 | `/index/search` | POST | Volltext-/Substring-Suche gegen den In-Memory-Index (leere/fehlende Namespaces → `default`). |


### PR DESCRIPTION
## Summary
- expose the Ask query parameter bounds in the OpenAPI schema and clamp requests between 1 and MAX_K
- extend coverage with a regression test that verifies zero-valued requests are raised to the minimum limit
- document the 1–100 Ask window in the README and core module reference

## Testing
- cargo test -p hauski-core

------
https://chatgpt.com/codex/tasks/task_e_68ff904cf978832c8c9266f58ab33295