### PR TITLE
Fix uv PATH handling in workflows

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -30,22 +30,28 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install uv 0.7.x
+      - name: Install uv
         run: |
           set -euo pipefail
-          curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_VERSION="0.7.*" sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          # Installiere die neueste verfügbare uv-Version (Installer erwartet exakte Tags, daher ohne Wildcard)
+          curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          # Für diesen Step PATH sofort setzen und auf 0.7.x pinnen
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          uv --version || true
+          uv self update 0.7.*
 
       - name: Ensure uv version (expect 0.7.x)
         run: |
           set -euo pipefail
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
           version="$(uv --version)"
           echo "$version"
           grep -E '^uv 0\.7\.' <<<"$version"
 
       - name: Cache uv
-        uses: actions/cache@13ea82a3905a986a1a4b52ebb478c82172884294
+        uses: actions/cache@13c3b5c0b52e77e8fa7b4e3d6a238602b25e9a3a # actions/cache@v4.0.2 (pinned)
         with:
           path: |
             ~/.cache/uv

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -69,10 +69,13 @@ jobs:
         if: ${{ hashFiles('pyproject.toml') != '' }}
         run: |
           set -euo pipefail
-          curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_VERSION="0.7.*" sh
+          # Installer erwartet exakte Release-Tags; installiere ohne Wildcard
+          curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          # Installation direkt auf 0.7.x entsprechend .wgx/profile.yml
+          # Für diesen Step PATH sofort setzen und gezielt auf 0.7.x bringen
+          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+          uv self update 0.7.*
           ver="$(uv --version || true)"
           echo "uv version: $ver"
           case "$ver" in


### PR DESCRIPTION
## Summary
- install uv without version wildcards in ci tooling workflows
- pin the installed binary to the 0.7.x line via `uv self update`
- export the uv installation paths immediately so installer steps can run `uv` without absolute paths
- align the cached action SHA with other workflows

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690056f072e4832c91ca5089fb141c82