### PR TITLE
Improve Lychee workflow robustness

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,71 @@
+name: Link Check (Lychee)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.md'
+      - '**/*.html'
+      - '.github/workflows/links.yml'
+      - '.lychee.toml'
+      - '.lycheeignore'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**/*.md'
+      - '**/*.html'
+      - '.github/workflows/links.yml'
+      - '.lychee.toml'
+      - '.lycheeignore'
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Für PR-Kommentare:
+  pull-requests: write
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Ensure report directory
+        run: mkdir -p lychee
+
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+
+      - name: Check links
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >
+            --config .lychee.toml
+            --no-progress
+            --verbose
+            --format markdown
+            --output lychee/out.md
+            "./**/*.md" "./**/*.html"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: PR comment with report
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && steps.lychee.outputs.exit_code != 0 }}
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            ⚠️ Lychee meldet Probleme. Siehe Artefakt **lychee/out.md**.
+            Exit code: ${{ steps.lychee.outputs.exit_code }}
+
+      - name: Upload report artifact
+        if: ${{ always() && steps.lychee.outputs.exit_code != 0 }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: lychee-report
+          path: lychee/out.md

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,41 @@
+# Lychee configuration (see https://lychee.cli.rs/)
+
+# Caching
+cache = true
+max_cache_age = "1d"
+cache_path = ".lycheecache"
+
+# Networking & robustness
+timeout = "10s"
+max_retries = 2
+retry_wait_time = "2s"
+max_redirects = 5
+accept = ["200..399"]
+user_agent = "heimgewebe-lychee-ci"
+require_https = true
+
+# Inputs are provided via workflow arguments; only exclude directories here.
+exclude_path = [
+  ".git",
+  "target",
+  "vendor",
+  "node_modules",
+  ".venv",
+  "site",
+  "dist",
+  "build"
+]
+
+# Exclude localhost-style URLs and ephemeral dev environments.
+exclude = [
+  "http://localhost(:[0-9]+)?",
+  "https://localhost(:[0-9]+)?",
+  "http://127\\.0\\.0\\.1(:[0-9]+)?",
+  "https://127\\.0\\.0\\.1(:[0-9]+)?",
+  "http://0\\.0\\.0\\.0(:[0-9]+)?",
+  "https://0\\.0\\.0\\.0(:[0-9]+)?",
+  ".*://(dev|test|staging)\\.[^\\s/]+"
+]
+
+# Ignore email addresses to reduce noise.
+exclude_email = true

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,10 @@
+# Lines specify URLs or regex patterns that Lychee should skip.
+# Keep dynamic or rate-limited endpoints here to avoid flaky CI runs.
+#
+# Examples:
+# https://example.com/some-path?token=*
+# ^https://api\.github\.com/.*
+# ^https://.*\.cloudfront\.net/.*
+
 https://github.com/heimgewebe/hausKI/actions/workflows/coverage.yml?query=branch%3Amain
 https://github.com/heimgewebe/hausKI/actions/workflows/security.yml?query=branch%3Amain


### PR DESCRIPTION
## Summary
- cancel redundant link check runs by introducing workflow concurrency controls
- ensure the Lychee report artifact is created by pre-creating the directory and writing markdown output
- guard PR comments for forked contributions and require HTTPS targets in Lychee scans

## Testing
- not run (workflow-only change)

------
https://chatgpt.com/codex/tasks/task_e_690082c6b014832cbf50d0d105bc3d15