### PR TITLE
Update actions cache to v4 in CI tools workflow

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -51,7 +51,7 @@ jobs:
           grep -E '^uv 0\.7\.' <<<"$version"
 
       - name: Cache uv
-        uses: actions/cache@13c3b5c0b52e77e8fa7b4e3d6a238602b25e9a3a # actions/cache@v4.0.2 (pinned)
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/uv


### PR DESCRIPTION
## Summary
- update the cache step in ci-tools workflow to use the maintained actions/cache@v4 release

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69008e847024832cb3e51943db2894a9