### PR TITLE
Use Python guard for jsonschema lock enforcement

### DIFF
--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           fetch-depth: 0
 
+      # --- uv bootstrap -------------------------------------------------------
       - name: Install uv
         run: |
           set -euo pipefail
@@ -49,6 +50,76 @@ jobs:
           version="$(uv --version)"
           echo "$version"
           grep -E '^uv 0\.7\.' <<<"$version"
+
+      # --- Sanity check: lock must exist and be in sync for dev extra ----------
+      - name: Check uv.lock presence
+        run: |
+          test -f uv.lock || { echo "Missing uv.lock. Run: uv lock --extra dev"; exit 1; }
+
+      - name: Assert jsonschema pinned in uv.lock
+        run: |
+          python3 - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import sys
+          from pathlib import Path
+
+          lock_path = Path("uv.lock")
+          if not lock_path.exists():
+            print("uv.lock not found. Run: uv lock --extra dev", file=sys.stderr)
+            sys.exit(1)
+
+          raw_text = lock_path.read_text(encoding="utf-8")
+
+          def has_jsonschema_from_toml() -> bool:
+            try:
+              try:
+                import tomllib  # type: ignore[attr-defined]
+              except ModuleNotFoundError:
+                import tomli as tomllib  # type: ignore[no-redef]
+            except ModuleNotFoundError:
+              return False
+
+            try:
+              data = tomllib.loads(raw_text)
+            except Exception:
+              return False
+
+            packages = data.get("package", [])
+            for package in packages:
+              name = package.get("name")
+              if isinstance(name, str) and name.lower() == "jsonschema":
+                return True
+            return False
+
+          def has_jsonschema_from_json() -> bool:
+            try:
+              data = json.loads(raw_text)
+            except json.JSONDecodeError:
+              return False
+            packages = data.get("package", [])
+            for package in packages:
+              name = package.get("name")
+              if isinstance(name, str) and name.lower() == "jsonschema":
+                return True
+            return False
+
+          def has_jsonschema_from_text() -> bool:
+            lowered = raw_text.lower()
+            return 'name = "jsonschema"' in lowered or '"name": "jsonschema"' in lowered
+
+          if not (
+              has_jsonschema_from_toml()
+              or has_jsonschema_from_json()
+              or has_jsonschema_from_text()
+          ):
+            print("jsonschema not found in uv.lock.")
+            print("Fix locally:")
+            print("  uv lock --upgrade-package jsonschema==4.23.0")
+            print("  # oder gesamtes Dev-Set refreshen: uv lock --extra dev")
+            sys.exit(1)
+          PY
 
       - name: Cache uv
         uses: actions/cache@13c3b5c0b52e77e8fa7b4e3d6a238602b25e9a3a # actions/cache@v4.0.2 (pinned)

--- a/README.md
+++ b/README.md
@@ -523,4 +523,15 @@ Für eine dauerhafte Installation kann `hauski` als `systemd`-Dienst konfigurier
 ## Weiterführende Dokumente
 - [`hauski-skizze.md`](hauski-skizze.md) – Vision, Funktionsumfang, Performance-Budgets, Security-Ansatz.
 - [`hauski-stack.md`](hauski-stack.md) – Technologiewahl, Tooling, CI-Strategie und Testpyramide.
+- [`docs/vision/multi-agent-rag.md`](docs/vision/multi-agent-rag.md) – Orchestrierung der spezialisierten Agenten inkl. Contracts.
+  Einstieg über `just agents.sync` (Template spiegeln) und `just agents.run` (Dry-Run).
 
+### Python-Dev Abhängigkeiten & Lockfile (uv)
+- CI erwartet **reproduzierbare** Installs: `uv sync --extra dev --locked --frozen`.
+- Wenn du `pyproject.toml` änderst (z. B. neue Dev-Lib wie `jsonschema==4.23.0`):
+  1. `uv lock --extra dev`  
+     _oder gezielt:_ `uv lock --upgrade-package jsonschema==4.23.0`
+  2. `git add uv.lock`
+  3. commit & push
+
+Ohne aktualisiertes `uv.lock` bricht CI mit einem klaren Hinweis ab.


### PR DESCRIPTION
## Summary
- replace the jsonschema grep in the CI tools workflow with a Python-based parser that supports TOML, JSON, and textual fallbacks to avoid false negatives

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69008f6a13dc832cb00bcc42e6802861