### PR TITLE
Add configurable chat model and Ollama upstream integration

### DIFF
--- a/configs/flags.yaml
+++ b/configs/flags.yaml
@@ -4,7 +4,9 @@
 # self-contained. This is intended for local/offline usage or hardening
 # scenarios. Overrides via HAUSKI_SAFE_MODE take precedence over this file.
 safe_mode: false
-# Optional: OpenAI-compatible upstream handling chat requests (e.g. llama.cpp --server)
+# Optional: Upstream handling chat requests (e.g. Ollama or llama.cpp --server)
 # Example:
 #   http://127.0.0.1:8081
 chat_upstream_url: null
+# Optional: Explicit chat model identifier to pass upstream (e.g. llama3)
+chat_model: null

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -103,7 +103,7 @@ pub struct BuildInfoLabels {
 impl EncodeLabelSet for BuildInfoLabels {
     fn encode(
         &self,
-        mut encoder: prometheus_client::encoding::LabelSetEncoder<'_>,
+        encoder: &mut prometheus_client::encoding::LabelSetEncoder<'_>,
     ) -> Result<(), fmt::Error> {
         ("service", self.service).encode(encoder.encode_label())?;
         Ok(())
@@ -248,7 +248,7 @@ impl HttpDurationLabels {
 impl EncodeLabelSet for HttpDurationLabels {
     fn encode(
         &self,
-        mut encoder: prometheus_client::encoding::LabelSetEncoder<'_>,
+        encoder: &mut prometheus_client::encoding::LabelSetEncoder<'_>,
     ) -> Result<(), fmt::Error> {
         ("method", self.method.as_str()).encode(encoder.encode_label())?;
         ("path", self.path).encode(encoder.encode_label())?;
@@ -276,7 +276,7 @@ impl HttpLabels {
 impl EncodeLabelSet for HttpLabels {
     fn encode(
         &self,
-        mut encoder: prometheus_client::encoding::LabelSetEncoder<'_>,
+        encoder: &mut prometheus_client::encoding::LabelSetEncoder<'_>,
     ) -> Result<(), fmt::Error> {
         ("method", self.method.as_str()).encode(encoder.encode_label())?;
         ("path", self.path).encode(encoder.encode_label())?;


### PR DESCRIPTION
## Summary
- add a `chat_model` flag/environment override alongside the upstream URL handling
- call Ollama's `/api/chat` endpoint for chat forwarding and return the configured model in responses
- document the new flag in `configs/flags.yaml` and adjust metrics label encoders for compatibility

## Testing
- cargo test -p hauski-core

------
https://chatgpt.com/codex/tasks/task_e_690127965f68832c90c2aa41ed7cf787