### PR TITLE
Include chat flag model when building ChatCfg

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -112,13 +112,10 @@ impl AppState {
         models: ModelsFile,
         routing: RoutingPolicy,
         flags: FeatureFlags,
+        chat_cfg: Arc<chat::ChatCfg>,
         expose_config: bool,
     ) -> Self {
         let mut registry = Registry::default();
-
-        let chat_cfg = Arc::new(chat::ChatCfg::from_env_and_flags(
-            flags.chat_upstream_url.clone(),
-        ));
 
         let build_info = Family::<BuildInfoLabels, Gauge>::default();
         build_info
@@ -420,7 +417,11 @@ pub fn build_app_with_state(
     expose_config: bool,
     allowed_origin: HeaderValue,
 ) -> (Router, AppState) {
-    let state = AppState::new(limits, models, routing, flags, expose_config);
+    let chat_cfg = Arc::new(chat::ChatCfg::from_env_and_flags(
+        flags.chat_upstream_url.clone(),
+        flags.chat_model.clone(),
+    ));
+    let state = AppState::new(limits, models, routing, flags, chat_cfg, expose_config);
     let allowed_origin = Arc::new(allowed_origin);
 
     // --- Request guards ------------------------------------------------------

--- a/crates/core/tests/metrics_smoke.rs
+++ b/crates/core/tests/metrics_smoke.rs
@@ -1,5 +1,5 @@
 //! Minimaler Smoke-Test für `/metrics`.
-//! 
+//!
 //! Dieser Test ist bewusst als `#[ignore]` markiert, damit reguläre CI-Läufe
 //! nicht scheitern, wenn kein Server läuft. Er kann gezielt aktiviert werden:
 //!
@@ -29,7 +29,11 @@ async fn metrics_endpoint_exposes_prometheus_text() {
         .await
         .expect("request to /metrics failed");
 
-    assert_eq!(resp.status(), StatusCode::OK, "unexpected status for /metrics");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "unexpected status for /metrics"
+    );
 
     // Content-Type sollte Prometheus-Textformat sein
     let ctype = resp
@@ -53,4 +57,3 @@ async fn metrics_endpoint_exposes_prometheus_text() {
         &body.as_bytes().get(0..64)
     );
 }
-


### PR DESCRIPTION
## Summary
- allow ChatCfg::from_env_and_flags to fall back to the flag-defined model when no env override is set
- update chat configuration tests to cover env, legacy, and flag fallbacks, plus the empty case
- pass the feature flag model into ChatCfg creation inside build_app_with_state

## Testing
- cargo test -p hauski-core

------
https://chatgpt.com/codex/tasks/task_e_6901380acdd8832c91dd0488b78823cf