### PR TITLE
Adjust reqwest workspace features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ http-body-util = "0.1"
 serial_test = "3"
 tempfile = "3"
 # sqlx bewusst nicht vorgezogen, bis erste DB-Crate existiert
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots", "gzip"] }
 url = "2"
 rusqlite = { version = "0.37.0", features = ["bundled"] }
 chrono = { version = "0.4", features = ["clock"] }


### PR DESCRIPTION
## Summary
- enable deterministic webpki CA bundle and gzip support for the workspace reqwest dependency while keeping default features disabled

## Testing
- cargo check -p hauski-core *(fails: unable to download crates due to 403 CONNECT tunnel failure)*

------
https://chatgpt.com/codex/tasks/task_e_690138062a48832c9dfc45c10f400e64