### PR TITLE
Log HTML coverage report path

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -63,34 +63,37 @@ jobs:
           RUST_BACKTRACE: "1"
           CARGO_TERM_COLOR: "always"
         run: |
-          # Measure only the runtime-relevant crates
+          # measure only the runtime-relevant crates
           PKGS="--package hauski-core --package hauski-indexd"
+          echo "PKGS=$PKGS"
+          mkdir -p target/coverage/html
 
-          # 1) Run full coverage with HTML report
+          # 1) Erzeuge HTML-Report (inkl. Testlauf)
           cargo llvm-cov $PKGS \
             --all-features \
             --doctests \
             --fail-under-lines 65 \
             --html --output-path target/coverage/html
+          echo "HTML report: target/coverage/html/index.html"
 
-          # 2) Generate LCOV report from existing profiles
+          # 2) Erzeuge LCOV-Report aus den bereits gesammelten Profilen
           cargo llvm-cov report \
             --lcov --output-path lcov.info
 
-      - name: Upload LCOV report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: lcov.info
-          path: lcov.info
-          retention-days: 7
-
-      - name: Upload HTML coverage report
+      - name: Upload HTML coverage
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-html
           path: target/coverage/html
+          retention-days: 7
+
+      - name: Upload lcov
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov.info
+          path: lcov.info
           retention-days: 7
 
       # Coveralls (optional)


### PR DESCRIPTION
## Summary
- log the generated HTML coverage report path after cargo llvm-cov runs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6901ae882c9c832c8fd131b0d4a3fb29