### PR TITLE
Document chat configuration requirements and add chat availability test

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -28,5 +28,5 @@ utoipa.workspace = true
 [dev-dependencies]
 tower = { workspace = true, features = ["util"] }
 http-body-util.workspace = true
-serial_test.workspace = true
+serial_test = "3"
 tempfile.workspace = true

--- a/crates/core/src/chat.rs
+++ b/crates/core/src/chat.rs
@@ -1,26 +1,88 @@
-use std::time::Instant;
+use std::{env, time::Instant};
 
 use axum::{
     extract::State,
-    http::{Method, StatusCode},
+    http::{HeaderMap, HeaderValue, Method, StatusCode},
     response::IntoResponse,
     Json,
 };
 use serde::{Deserialize, Serialize};
+#[allow(unused_imports)]
+use serde_json::json;
 use tracing::{debug, warn};
 use utoipa::ToSchema;
 
 use crate::{chat_upstream::call_ollama_chat, AppState};
 
-#[derive(Debug, Deserialize, Serialize, ToSchema)]
+#[derive(Debug, Clone)]
+pub struct ChatCfg {
+    pub upstream_url: Option<String>,
+    pub model: Option<String>,
+    pub client: reqwest::Client,
+}
+
+impl ChatCfg {
+    pub fn new(upstream_url: Option<String>, model: Option<String>) -> Self {
+        Self {
+            upstream_url,
+            model,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    pub fn from_env_and_flags(flag_upstream: Option<String>, flag_model: Option<String>) -> Self {
+        let upstream_env =
+            env_var("HAUSKI_CHAT_UPSTREAM_URL").or_else(|| env_var("CHAT_UPSTREAM_URL"));
+        let upstream_url = upstream_env.or(flag_upstream);
+        let model = env_var("HAUSKI_CHAT_MODEL").or(flag_model);
+
+        Self::new(upstream_url, model)
+    }
+}
+
+fn env_var(key: &str) -> Option<String> {
+    match env::var(key) {
+        Ok(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+        Err(_) => None,
+    }
+}
+
+/// Allowed roles for chat messages.
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+#[schema(value_type = String, title = "ChatRole", example = "user")]
+pub enum ChatRole {
+    System,
+    User,
+    Assistant,
+    #[serde(alias = "tool", alias = "function")]
+    Tool,
+}
+
+const MAX_MESSAGES: usize = 32;
+const MAX_CHARS_PER_MSG: usize = 16_000;
+const RETRY_AFTER_SECS: &str = "30";
+
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+#[schema(title = "ChatMessage", example = json!({"role":"user","content":"Hallo HausKI?"}))]
 pub struct ChatMessage {
     /// Role of the message author (e.g. user, system, assistant).
-    pub role: String,
+    pub role: ChatRole,
     /// Natural language content submitted by the author.
     pub content: String,
 }
 
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+#[schema(title = "ChatResponse", example = json!({"content":"Hallo! Wie kann ich helfen?","model":"llama3.1-8b-q4"}))]
 pub struct ChatResponse {
     /// Assistant message content produced by the upstream model.
     pub content: String,
@@ -28,20 +90,151 @@ pub struct ChatResponse {
     pub model: String,
 }
 
-#[derive(Debug, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+#[schema(title = "ChatRequest", example = json!({"messages":[{"role":"user","content":"Hallo HausKI?"}]}))]
 pub struct ChatRequest {
     /// Sequence of messages forming the current conversation turn.
     pub messages: Vec<ChatMessage>,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+#[schema(title = "ChatStubResponse", example = json!({
+    "status": "unavailable",
+    "message": "chat pipeline not wired yet, please configure HAUSKI_CHAT_UPSTREAM_URL"
+}))]
 pub struct ChatStubResponse {
-    /// Static status marker highlighting that the endpoint is not wired yet.
+    /// Stub information for unimplemented or failed chat routes.
     pub status: String,
-    /// Human readable explanation for clients.
     pub message: String,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn clear_env_vars() {
+        for key in [
+            "HAUSKI_CHAT_UPSTREAM_URL",
+            "CHAT_UPSTREAM_URL",
+            "HAUSKI_CHAT_MODEL",
+        ] {
+            std::env::remove_var(key);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn from_env_prefers_primary_env_over_flag() {
+        clear_env_vars();
+        std::env::set_var("HAUSKI_CHAT_UPSTREAM_URL", " https://example.invalid/chat ");
+        std::env::set_var("HAUSKI_CHAT_MODEL", " llama-3.1 ");
+
+        let cfg = ChatCfg::from_env_and_flags(
+            Some("https://flag.invalid".to_string()),
+            Some("flag-model".to_string()),
+        );
+
+        assert_eq!(
+            cfg.upstream_url.as_deref(),
+            Some("https://example.invalid/chat")
+        );
+        assert_eq!(cfg.model.as_deref(), Some("llama-3.1"));
+
+        clear_env_vars();
+    }
+
+    #[test]
+    #[serial]
+    fn from_env_uses_legacy_variable_when_new_is_missing() {
+        clear_env_vars();
+        std::env::set_var("CHAT_UPSTREAM_URL", "http://legacy.invalid");
+
+        let cfg = ChatCfg::from_env_and_flags(None, Some("flag-model".to_string()));
+
+        assert_eq!(cfg.upstream_url.as_deref(), Some("http://legacy.invalid"));
+        assert_eq!(cfg.model.as_deref(), Some("flag-model"));
+
+        clear_env_vars();
+    }
+
+    #[test]
+    #[serial]
+    fn from_env_falls_back_to_flag_when_env_empty() {
+        clear_env_vars();
+        std::env::set_var("HAUSKI_CHAT_UPSTREAM_URL", "   ");
+
+        let cfg = ChatCfg::from_env_and_flags(
+            Some("https://flag.invalid".to_string()),
+            Some("flag-model".to_string()),
+        );
+
+        assert_eq!(cfg.upstream_url.as_deref(), Some("https://flag.invalid"));
+        assert_eq!(cfg.model.as_deref(), Some("flag-model"));
+
+        clear_env_vars();
+    }
+
+    #[test]
+    #[serial]
+    fn from_env_returns_none_when_flags_absent() {
+        clear_env_vars();
+
+        let cfg = ChatCfg::from_env_and_flags(None, None);
+
+        assert!(cfg.upstream_url.is_none());
+        assert!(cfg.model.is_none());
+
+        clear_env_vars();
+    }
+}
+
+/// Lightweight input validation to protect upstreams and keep error reporting clear.
+fn validate_chat_request(req: &ChatRequest) -> Result<(), ChatStubResponse> {
+    if req.messages.is_empty() {
+        return Err(ChatStubResponse {
+            status: "bad_request".to_string(),
+            message: "messages must not be empty".to_string(),
+        });
+    }
+
+    if req.messages.len() > MAX_MESSAGES {
+        return Err(ChatStubResponse {
+            status: "too_many_messages".to_string(),
+            message: format!("messages limited to {MAX_MESSAGES}"),
+        });
+    }
+
+    if let Some((index, _)) = req
+        .messages
+        .iter()
+        .enumerate()
+        .find(|(_, message)| message.content.trim().is_empty())
+    {
+        return Err(ChatStubResponse {
+            status: "bad_request".to_string(),
+            message: format!("message {index} must not be empty"),
+        });
+    }
+
+    if let Some((index, _)) = req
+        .messages
+        .iter()
+        .enumerate()
+        .find(|(_, message)| message.content.chars().count() > MAX_CHARS_PER_MSG)
+    {
+        return Err(ChatStubResponse {
+            status: "message_too_long".to_string(),
+            message: format!("message {index} exceeds {MAX_CHARS_PER_MSG} chars"),
+        });
+    }
+
+    Ok(())
+}
+
+// Hinweis: Wir dokumentieren die `Retry-After`-Header für 503-Antworten.
 #[utoipa::path(
     post,
     path = "/v1/chat",
@@ -58,9 +251,17 @@ pub struct ChatStubResponse {
             body = ChatStubResponse
         ),
         (
-            status = 501,
-            description = "Chat endpoint not yet implemented",
+            status = 400,
+            description = "Invalid chat request payload",
             body = ChatStubResponse
+        ),
+        (
+            status = 503,
+            description = "Chat endpoint not currently available",
+            body = ChatStubResponse,
+            headers(
+                ("Retry-After" = String, description = "Client backoff in seconds")
+            )
         )
     ),
     tag = "core"
@@ -69,11 +270,18 @@ pub async fn chat_handler(
     State(state): State<AppState>,
     Json(chat_request): Json<ChatRequest>,
 ) -> axum::response::Response {
-    let flags = state.flags();
-    if let Some(base_url) = flags.chat_upstream_url.clone() {
-        if let Some(model) = flags.chat_model.clone() {
-            let started = Instant::now();
-            let client = reqwest::Client::new();
+    let started = Instant::now();
+
+    if let Err(payload) = validate_chat_request(&chat_request) {
+        let status = StatusCode::BAD_REQUEST;
+        state.record_http_observation(Method::POST, "/v1/chat", status, started);
+        return (status, Json(payload)).into_response();
+    }
+
+    let chat_cfg = state.chat_cfg();
+    if let Some(base_url) = chat_cfg.upstream_url.clone() {
+        if let Some(model) = chat_cfg.model.clone() {
+            let client = chat_cfg.client.clone();
 
             match call_ollama_chat(&client, &base_url, &model, &chat_request.messages).await {
                 Ok(content) => {
@@ -96,24 +304,32 @@ pub async fn chat_handler(
         }
 
         warn!("chat request received but no chat model is configured");
-        let started = Instant::now();
-        let status = StatusCode::NOT_IMPLEMENTED;
+        let status = StatusCode::SERVICE_UNAVAILABLE;
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::RETRY_AFTER,
+            HeaderValue::from_static(RETRY_AFTER_SECS),
+        );
         state.record_http_observation(Method::POST, "/v1/chat", status, started);
         let payload = ChatStubResponse {
-            status: "not_implemented".to_string(),
+            status: "unavailable".to_string(),
             message: "missing HAUSKI_CHAT_MODEL".to_string(),
         };
-        return (status, Json(payload)).into_response();
+        return (status, headers, Json(payload)).into_response();
     }
 
     warn!("chat request received but no chat upstream is configured");
-    let started = Instant::now();
-    let status = StatusCode::NOT_IMPLEMENTED;
+    let status = StatusCode::SERVICE_UNAVAILABLE;
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::RETRY_AFTER,
+        HeaderValue::from_static(RETRY_AFTER_SECS),
+    );
     state.record_http_observation(Method::POST, "/v1/chat", status, started);
     let payload = ChatStubResponse {
-        status: "not_implemented".to_string(),
+        status: "unavailable".to_string(),
         message: "chat pipeline not wired yet, please configure HAUSKI_CHAT_UPSTREAM_URL"
             .to_string(),
     };
-    (status, Json(payload)).into_response()
+    (status, headers, Json(payload)).into_response()
 }

--- a/crates/core/tests/chat_unconfigured.rs
+++ b/crates/core/tests/chat_unconfigured.rs
@@ -1,0 +1,58 @@
+use axum::body::Body;
+use hauski_core::{build_app_with_state, FeatureFlags, Limits, ModelsFile, RoutingPolicy};
+use http::{Request, StatusCode};
+use hyper::body::to_bytes;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+fn default_app() -> axum::Router {
+    for key in [
+        "HAUSKI_CHAT_UPSTREAM_URL",
+        "CHAT_UPSTREAM_URL",
+        "HAUSKI_CHAT_MODEL",
+    ] {
+        std::env::remove_var(key);
+    }
+
+    let limits = Limits::default();
+    let models = ModelsFile::default();
+    let routing = RoutingPolicy::default();
+    let flags = FeatureFlags::default();
+    let allowed_origin = http::HeaderValue::from_static("*");
+    let (app, _state) = build_app_with_state(limits, models, routing, flags, false, allowed_origin);
+    app
+}
+
+#[tokio::test]
+async fn chat_returns_503_when_unconfigured() {
+    let app = default_app();
+    let payload = json!({
+        "messages": [
+            {"role": "user", "content": "Ping?"}
+        ]
+    });
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/v1/chat")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(payload.to_string()))
+                .expect("failed to build request"),
+        )
+        .await
+        .expect("request failed");
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let retry_after = response
+        .headers()
+        .get(http::header::RETRY_AFTER)
+        .expect("missing Retry-After header")
+        .to_str()
+        .expect("Retry-After not valid utf8");
+    assert_eq!(retry_after, "30");
+
+    let body_bytes = to_bytes(response.into_body()).await.expect("body bytes");
+    let stub: Value = serde_json::from_slice(&body_bytes).expect("stub response");
+    assert_eq!(stub["status"], "unavailable");
+}

--- a/crates/core/tests/metrics_smoke.rs
+++ b/crates/core/tests/metrics_smoke.rs
@@ -1,5 +1,5 @@
 //! Minimaler Smoke-Test für `/metrics`.
-//! 
+//!
 //! Dieser Test ist bewusst als `#[ignore]` markiert, damit reguläre CI-Läufe
 //! nicht scheitern, wenn kein Server läuft. Er kann gezielt aktiviert werden:
 //!
@@ -29,7 +29,11 @@ async fn metrics_endpoint_exposes_prometheus_text() {
         .await
         .expect("request to /metrics failed");
 
-    assert_eq!(resp.status(), StatusCode::OK, "unexpected status for /metrics");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "unexpected status for /metrics"
+    );
 
     // Content-Type sollte Prometheus-Textformat sein
     let ctype = resp
@@ -53,4 +57,3 @@ async fn metrics_endpoint_exposes_prometheus_text() {
         &body.as_bytes().get(0..64)
     );
 }
-

--- a/hauski-stack.md
+++ b/hauski-stack.md
@@ -63,7 +63,7 @@ hauski/
 
 ## 3) APIs, Policies, Modelle
 
-* **Chat (MVP):** `POST /v1/chat` (stub → `501 Not Implemented`, OpenAI-kompatible Routen folgen)
+* **Chat (MVP):** `POST /v1/chat` → nutzt `ChatCfg` + Ollama-Upstream; setzt `HAUSKI_CHAT_UPSTREAM_URL` (+ optional `HAUSKI_CHAT_MODEL`), sonst `503` mit `Retry-After` (siehe `crates/core/tests/chat_unconfigured.rs`)
 * **Spezial:** `POST /asr/transcribe`, `/obsidian/canvas/suggest`, `/code/pr/draft`, `/audio/profile`
 * **Policies:**
 


### PR DESCRIPTION
## Summary
- update the chat role schema metadata to use `value_type` for future utoipa compatibility
- document the required chat configuration flags and fallback behaviour in `hauski-stack.md`
- add an integration test that proves the chat endpoint responds with 503 and Retry-After when no upstream is configured
- factor the shared Retry-After header constant into `chat.rs` and link the stack docs back to the availability test

## Testing
- `cargo check -p hauski-core` *(fails: crates.io index blocked with HTTP 403 while downloading `encoding_rs`)*

------
https://chatgpt.com/codex/tasks/task_e_69012eb1e75c832cb1701dec4035592d