### PR TITLE
Improve uv bootstrap safety

### DIFF
--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -38,9 +38,16 @@ jobs:
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            pip-${{ runner.os }}-
+
       - name: Install PyYAML
         run: |
-          pip install --disable-pip-version-check --upgrade pip
           pip install --disable-pip-version-check pyyaml==6.0.2
 
       - name: Run schema-lite check
@@ -81,45 +88,103 @@ jobs:
         if: ${{ hashFiles('pyproject.toml') != '' }}
         run: |
           set -euo pipefail
-          # Installer mit einfachem Retry gegen temporäre Netzflaps
-          export UV_INSTALL_TIMEOUT=60
-          for i in 1 2 3; do
-            if curl -LsSf https://astral.sh/uv/install.sh | sh; then break; fi
-            if [ "$i" -eq 3 ]; then
-              echo "::error::uv installation failed after retries"
-              exit 1
-            fi
-            echo "retry $i/3"; sleep $((2*i));
-          done
+          python -m pip install --user --disable-pip-version-check 'uv>=0.8,<0.9'
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          # Für diesen Step PATH sofort setzen (Installer dropt in ~/.local/bin / ~/.cargo/bin)
-          export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
-          # Installation validieren NACH PATH-Update
-          command -v uv >/dev/null 2>&1 || { echo "::error::uv installation failed"; exit 1; }
-          # Auf ≥0.8 bringen, falls Runner ältere Version gecached hatte
+          export PATH="$HOME/.local/bin:$PATH"
+          if ! command -v uv >/dev/null 2>&1; then
+            echo "::error::uv not found after pip install"
+            exit 1
+          fi
           ver="$(uv --version || true)"
           echo "uv version: $ver"
           if [[ "$ver" =~ ^uv\ ([0-9]+)\.([0-9]+)\. ]]; then
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
             if ! { [ "$major" -gt 0 ] || { [ "$major" -eq 0 ] && [ "$minor" -ge 8 ]; }; }; then
-              echo "uv version <0.8 detected → attempting self update"
-              uv self update 0.8.* || uv self update || true
-              ver="$(uv --version || true)"
-              echo "uv version after update: $ver"
-              if [[ "$ver" =~ ^uv\ ([0-9]+)\.([0-9]+)\. ]]; then
-                major="${BASH_REMATCH[1]}"
-                minor="${BASH_REMATCH[2]}"
-              fi
-              if ! { [ "$major" -gt 0 ] || { [ "$major" -eq 0 ] && [ "$minor" -ge 8 ]; }; }; then
-                echo "::error::uv 0.8.x oder höher erwartet, gefunden: $ver"
-                exit 1
-              fi
+              echo "::error::uv 0.8.x oder höher erwartet, gefunden: $ver"
+              echo "::notice::Bitte leere ggf. deinen Actions-Cache, falls eine alte uv-Version wiederhergestellt wurde."
+              exit 1
             fi
           else
             echo "::error::uv version konnte nicht geparst werden: $ver"
             exit 1
+          fi
+
+          if [ -f .wgx/profile.yml ] && [ -f pyproject.toml ]; then
+            WGX_PY="$(python - <<'PY'
+try:
+    import yaml  # type: ignore
+except Exception:
+    yaml = None
+
+def manual_parse(text: str) -> str:
+    fallback = "3.12"
+    lines = text.splitlines()
+    tooling = False
+    python = False
+    tooling_indent = None
+    python_indent = None
+    for line in lines:
+        raw = line.rstrip("\n")
+        stripped = raw.lstrip()
+        if not stripped or stripped.startswith('#'):
+            continue
+        indent = len(raw) - len(stripped)
+        if indent == 0:
+            tooling = stripped.startswith('tooling:')
+            python = False
+            tooling_indent = indent if tooling else None
+            continue
+        if tooling and tooling_indent is not None:
+            if indent <= tooling_indent:
+                tooling = False
+                python = False
+            elif stripped.startswith('python:'):
+                python = True
+                python_indent = indent
+                continue
+        if python and python_indent is not None:
+            if indent <= python_indent:
+                python = False
+            elif stripped.startswith('version:'):
+                value = stripped.split(':', 1)[1].strip().strip("'\"")
+                return value or fallback
+    return fallback
+
+try:
+    with open('.wgx/profile.yml', 'r', encoding='utf-8') as f:
+        content = f.read()
+except FileNotFoundError:
+    content = ''
+
+version = "3.12"
+if yaml:
+    try:
+        data = yaml.safe_load(content) or {}
+        version = str(data.get('tooling', {}).get('python', {}).get('version', '3.12'))
+    except Exception:
+        version = manual_parse(content)
+else:
+    version = manual_parse(content)
+
+version = '.'.join(version.split('.')[:2]) or '3.12'
+print(version)
+PY
+)"
+          else
+            WGX_PY="3.12"
+          fi
+
+          echo "WGX_PY=${WGX_PY}" >> "$GITHUB_ENV"
+
+          if [ -n "${WGX_PY:-}" ] && [ -f pyproject.toml ]; then
+            echo "Desired Python: ${WGX_PY}"
+            if ! uv python list --format json | grep -q "\"version\": \"${WGX_PY}"; then
+              echo "Installing managed Python ${WGX_PY} via uv…"
+              uv python install "${WGX_PY}"
+            else
+              echo "Managed Python ${WGX_PY} already present."
+            fi
           fi
 
           export UV_NO_SYNC_DOWNLOADS=1
@@ -132,6 +197,8 @@ jobs:
             uv lock
             uv sync --python-preference=only-managed
           fi
+
+          echo "Final uv version: $(uv --version)"
 
       - name: Done
         run: echo "wgx-guard passed ✅"

--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -2,6 +2,7 @@ version: 1
 
 # Ordered list of preferred execution environments for WGX tasks.
 env_priority:
+  - dev
   - default
   - devcontainer
   - devbox
@@ -11,7 +12,7 @@ env_priority:
 # Toolchain expectations for this repository.
 tooling:
   uv:
-    version: "0.7.x"
+    version: "0.8.x"
   python:
     version: "3.12"
     uv: true


### PR DESCRIPTION
## Summary
- cache pip downloads in the guard workflow
- install uv from pip, enforce 0.8.x, and manage Python detection before syncing
- prefer the dev environment profile and require uv 0.8.x in WGX metadata
- log the final uv version, provide guidance for outdated cached installs, and drop the redundant pip upgrade

## Testing
- not run (workflow-only change)

------
https://chatgpt.com/codex/tasks/task_e_6901b61ec668832ca816bd83257e32a0