### PR TITLE
Allow private crates in cargo-deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -27,8 +27,10 @@ allow = [
 confidence-threshold = 0.9
 # Wie mit problematischen Klassen umgehen:
 unlicensed = "deny"
-unknown = "deny"
+unknown-license = "deny"
 copyleft = "warn"
+# Optional: lokale Eigenlizenz (für hausKI-Repos)
+private = "allow"
 
 [bans]
 multiple-versions = "warn"


### PR DESCRIPTION
## Summary
- allow private crates in the cargo-deny license policy to support internal modules
- document the intent with an inline comment for future maintenance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6901b4e4c5fc832cb2b7f6b76e87212c