### PR TITLE
Run coverage workflow entirely on nightly toolchain

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,11 +30,11 @@ jobs:
         # Pin to fixed release for deterministic builds
         uses: actions/checkout@v4.2.2
 
+      # Stable bleibt Default-Toolchain für Build-Schritte außerhalb Coverage
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          components: llvm-tools-preview
 
       - name: Ensure vendor snapshot
         run: bash scripts/ensure-vendor.sh
@@ -49,11 +49,18 @@ jobs:
           cache-on-failure: true
           shared-key: ${{ runner.os }}-cov-${{ hashFiles('**/Cargo.lock') }}
 
+      # Coverage läuft komplett mit nightly + llvm-tools, um Versionsmischung zu vermeiden
+      - name: Install nightly with llvm-tools
+        run: |
+          rustup set profile minimal
+          rustup toolchain install nightly --no-self-update --component llvm-tools-preview
+          rustup component list --toolchain nightly | grep llvm-tools
+
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked --version 0.6.9
 
       - name: Clean coverage profiles
-        run: cargo llvm-cov clean --workspace
+        run: cargo +nightly llvm-cov clean --workspace
 
       - name: Run coverage (focused)
         env:
@@ -67,7 +74,7 @@ jobs:
           PKGS="--package hauski-core --package hauski-indexd"
           echo "PKGS=$PKGS"
           # 1) Erzeuge HTML-Report (inkl. Testlauf)
-          cargo llvm-cov $PKGS \
+          cargo +nightly llvm-cov $PKGS \
             --all-features \
             --doctests \
             --fail-under-lines 65 \
@@ -75,7 +82,7 @@ jobs:
           echo "HTML report: target/llvm-cov/html/index.html"
 
           # 2) Erzeuge LCOV-Report aus den bereits gesammelten Profilen
-          cargo llvm-cov report \
+          cargo +nightly llvm-cov report \
             --lcov --output-path lcov.info
 
       - name: Upload HTML coverage


### PR DESCRIPTION
## Summary
- keep the stable toolchain for build steps while installing nightly with llvm-tools for coverage
- execute cargo-llvm-cov clean/run/report via the nightly toolchain to avoid mixed LLVM tooling
- avoid installing llvm-tools-preview on the stable toolchain since coverage runs on nightly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901fb3c55b0832cbf4ca063d6a2fd90