### PR TITLE
Add mock Ollama smoke test to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,19 +322,8 @@ jobs:
           # Fall back to "stable" if the workflow-level environment variable is empty.
           toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}
       - uses: Swatinem/rust-cache@29f7d9a5c8d5a5ca45c8c7c3aa4642f3f7e87b94
-      - name: Build hauski-cli
-        run: cargo build -p hauski-cli
-      - name: Health smoke
-        run: |
-          set -euo pipefail
-          cargo run -p hauski-cli -- serve &
-          pid=$!
-          trap 'kill "$pid" 2>/dev/null || true' EXIT
-          sleep 1
-          curl -sf http://127.0.0.1:8080/health
-          kill "$pid"
-          wait "$pid" || true
-          trap - EXIT
+      - name: Health & chat smoke (mock ollama)
+        run: bash scripts/ci-smoke-chat.sh
   security:
     name: Rust — deny & audit
     needs: changes

--- a/scripts/ci-smoke-chat.sh
+++ b/scripts/ci-smoke-chat.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+ROOT="$(git rev-parse --show-toplevel)"
+LOG_CORE="${ROOT}/target/smoke-core.log"
+LOG_MOCK="${ROOT}/target/smoke-mock.log"
+MODEL="${MODEL:-mock-model}"
+
+cleanup() {
+  set +e
+  [[ -n "${CORE_PID:-}" ]] && kill "${CORE_PID}" 2>/dev/null || true
+  [[ -n "${MOCK_PID:-}" ]] && kill "${MOCK_PID}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+mkdir -p "${ROOT}/target"
+
+echo "[smoke] start mock-ollama…"
+python3 "${ROOT}/scripts/mock_ollama.py" >"${LOG_MOCK}" 2>&1 &
+MOCK_PID=$!
+
+echo "[smoke] wait mock /api/tags…"
+for i in {1..50}; do
+  if curl -fsS "http://127.0.0.1:11434/api/tags" >/dev/null; then break; fi
+  sleep 0.1
+  [[ $i -eq 50 ]] && { echo "mock did not start"; tail -n +200 "${LOG_MOCK}" || true; exit 1; }
+done
+
+export HAUSKI_CHAT_UPSTREAM_URL="http://127.0.0.1:11434"
+export HAUSKI_CHAT_MODEL="${MODEL}"
+
+echo "[smoke] build & run hauski core…"
+cargo build -q -p hauski-cli
+"${ROOT}/target/debug/hauski-cli" serve >"${LOG_CORE}" 2>&1 &
+CORE_PID=$!
+
+echo "[smoke] wait /health…"
+for i in {1..100}; do
+  if curl -fsS "http://127.0.0.1:8080/health" >/dev/null; then break; fi
+  sleep 0.1
+  [[ $i -eq 100 ]] && { echo "core did not start"; tail -n +200 "${LOG_CORE}" || true; exit 1; }
+done
+
+echo "[smoke] check /health"
+curl -fsS "http://127.0.0.1:8080/health" | grep -qi "ok"
+
+echo "[smoke] check /v1/chat"
+RESP="$(curl -sSf -X POST "http://127.0.0.1:8080/v1/chat" \
+  -H 'Content-Type: application/json' \
+  -d '{"messages":[{"role":"user","content":"Ping?"}]}' )"
+
+python3 - "$RESP" "$MODEL" <<'PY'
+import json, sys
+resp, model = sys.argv[1], sys.argv[2]
+payload = json.loads(resp)
+if payload.get("model") != model:
+    print("unexpected model:", payload.get("model"), "expected:", model)
+    raise SystemExit(1)
+content = payload.get("content","")
+if "(mock)" not in content:
+    print("unexpected content:", content)
+    raise SystemExit(1)
+PY
+
+echo "[smoke] success."

--- a/scripts/mock_ollama.py
+++ b/scripts/mock_ollama.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Minimaler Ollama-Mock (Stdlib):
+#  GET  /api/tags  -> {"models":[{"name":"llama3:8b"}]}
+#  POST /api/chat  -> {"message":{"content":"(mock) <echo>" }}
+import json, sys
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+HOST = "127.0.0.1"
+PORT = 11434
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, code:int, body:dict):
+        data = json.dumps(body).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        if self.path.startswith("/api/tags"):
+            self._send(200, {"models":[{"name":"llama3:8b"}]})
+        else:
+            self._send(404, {"error":"not found"})
+
+    def do_POST(self):
+        if self.path.startswith("/api/chat"):
+            length = int(self.headers.get("Content-Length","0"))
+            raw = self.rfile.read(length) if length > 0 else b"{}"
+            try:
+                payload = json.loads(raw.decode("utf-8"))
+            except Exception:
+                payload = {}
+            content = "(mock) ok"
+            for m in (payload.get("messages") or [])[::-1]:
+                if m.get("role") == "user":
+                    content = "(mock) " + str(m.get("content","")); break
+            self._send(200, {"message":{"content":content}})
+        else:
+            self._send(404, {"error":"not found"})
+
+def main():
+    print(f"mock-ollama listening on http://{HOST}:{PORT}", file=sys.stderr)
+    HTTPServer((HOST, PORT), Handler).serve_forever()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replace the CI health smoke job with a chat-focused script that runs against a mock Ollama service
- add a bash smoke test that boots the mock, starts hauski-cli via HAUSKI_CHAT_* env vars, and verifies /health and /v1/chat
- include a lightweight Python mock for the Ollama /api/tags and /api/chat endpoints used by the smoke test

## Testing
- scripts/ci-smoke-chat.sh


------
https://chatgpt.com/codex/tasks/task_e_690231d25634832c8c68aee681bf1114