### PR TITLE
Clarify related block sorting

### DIFF
--- a/tools/semantah/update_related.py
+++ b/tools/semantah/update_related.py
@@ -136,8 +136,20 @@ def build_related_map(
         getattr(block, label_list).append((target_node.title, edge.score))
 
     for block in related.values():
-        block.auto.sort(key=lambda item: (-item[1], item[0]))
-        block.review.sort(key=lambda item: (-item[1], item[0]))
+        # Sort: Score absteigend, Key aufsteigend (case-insensitive)
+        # item ist ein Tupel/Liste: (key, score) oder kompatibel
+        block.auto.sort(
+            key=lambda item: (
+                -item[1],
+                (item[0] if isinstance(item[0], str) else str(item[0])).casefold(),
+            )
+        )
+        block.review.sort(
+            key=lambda item: (
+                -item[1],
+                (item[0] if isinstance(item[0], str) else str(item[0])).casefold(),
+            )
+        )
 
     return related
 


### PR DESCRIPTION
## Summary
- sort related auto and review entries by score descending and title ascending in a case-insensitive manner
- guard against non-string titles when generating the sort key

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690397c9bb28832c968c33d63ec8b415