### PR TITLE
Allow smoke test host override

### DIFF
--- a/scripts/ci-smoke-chat.sh
+++ b/scripts/ci-smoke-chat.sh
@@ -2,10 +2,27 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
+# CI Smoke-Test:
+# - startet Mock-Ollama (scripts/mock_ollama.py)
+# - startet HausKI-Core mit Env-Verdrahtung auf den Mock
+# - prüft /health (200) und /v1/chat (Modell + Content)
+
 ROOT="$(git rev-parse --show-toplevel)"
 LOG_CORE="${ROOT}/target/smoke-core.log"
 LOG_MOCK="${ROOT}/target/smoke-mock.log"
 MODEL="${MODEL:-mock-model}"
+HOST="${HOST:-http://127.0.0.1:8080}"
+BIND="${HOST#*://}"
+if [[ -z "${BIND}" || "${BIND}" == "${HOST}" ]]; then
+  echo "unable to derive bind address from HOST='${HOST}'" >&2
+  exit 1
+fi
+
+# Tool-Prüfung
+command -v python3 >/dev/null 2>&1 || { echo "python3 missing" >&2; exit 127; }
+command -v cargo   >/dev/null 2>&1 || { echo "cargo missing"   >&2; exit 127; }
+command -v curl    >/dev/null 2>&1 || { echo "curl missing"    >&2; exit 127; }
+command -v jq      >/dev/null 2>&1 || { echo "jq missing"      >&2; exit 127; }
 
 cleanup() {
   set +e
@@ -24,7 +41,7 @@ echo "[smoke] wait mock /api/tags…"
 for i in {1..50}; do
   if curl -fsS "http://127.0.0.1:11434/api/tags" >/dev/null; then break; fi
   sleep 0.1
-  [[ $i -eq 50 ]] && { echo "mock did not start"; tail -n +200 "${LOG_MOCK}" || true; exit 1; }
+  [[ $i -eq 50 ]] && { echo "mock did not start"; tail -n 200 "${LOG_MOCK}" || true; exit 1; }
 done
 
 export HAUSKI_CHAT_UPSTREAM_URL="http://127.0.0.1:11434"
@@ -32,23 +49,23 @@ export HAUSKI_CHAT_MODEL="${MODEL}"
 
 echo "[smoke] build & run hauski core…"
 cargo build -q -p hauski-cli
-"${ROOT}/target/debug/hauski-cli" serve >"${LOG_CORE}" 2>&1 &
+RUST_LOG="${RUST_LOG:-warn}" "${ROOT}/target/debug/hauski-cli" serve --bind "${BIND}" >"${LOG_CORE}" 2>&1 &
 CORE_PID=$!
 
 echo "[smoke] wait /health…"
 for i in {1..100}; do
-  if curl -fsS "http://127.0.0.1:8080/health" >/dev/null; then break; fi
+  if curl -fsS "${HOST}/health" >/dev/null; then break; fi
   sleep 0.1
-  [[ $i -eq 100 ]] && { echo "core did not start"; tail -n +200 "${LOG_CORE}" || true; exit 1; }
+  [[ $i -eq 100 ]] && { echo "core did not start"; tail -n 200 "${LOG_CORE}" || true; exit 1; }
 done
 
 echo "[smoke] check /health"
-curl -fsS "http://127.0.0.1:8080/health" | grep -qi "ok"
+curl -fsS "${HOST}/health" | grep -qi "ok"
 
 echo "[smoke] check /v1/chat"
-RESP="$(curl -sSf -X POST "http://127.0.0.1:8080/v1/chat" \
+RESP="$(curl -sSf --max-time 10 -X POST "${HOST}/v1/chat" \
   -H 'Content-Type: application/json' \
-  -d '{"messages":[{"role":"user","content":"Ping?"}]}' )"
+  -d '{"messages":[{"role":"user","content":"Ping?"}]}')"
 
 python3 - "$RESP" "$MODEL" <<'PY'
 import json, sys
@@ -58,7 +75,7 @@ if payload.get("model") != model:
     print("unexpected model:", payload.get("model"), "expected:", model)
     raise SystemExit(1)
 content = payload.get("content","")
-if "(mock)" not in content:
+if not content or "(mock)" not in content:
     print("unexpected content:", content)
     raise SystemExit(1)
 PY


### PR DESCRIPTION
## Summary
- derive the bind address from the HOST setting so the smoke test can run HausKI on alternate ports
- keep the existing HOST-based health and chat checks while validating the derived bind value

## Testing
- scripts/ci-smoke-chat.sh

------
https://chatgpt.com/codex/tasks/task_e_690397bed0bc832ca773785b4bad07a0