### PR TITLE
Clarify jsonschema dev extra note

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
   "pytest>=8.3",
   "rich>=13.9",
   "uvicorn[standard]>=0.32",
+  # Keep jsonschema in the dev extra so the uv.lock pin stays reachable for CI.
   "jsonschema==4.23.0",
 ]
 


### PR DESCRIPTION
## Summary
- clarify that the jsonschema dev extra pin is required so CI can find the uv.lock entry

## Testing
- `uv sync --extra dev --locked --frozen` *(fails: the argument '--locked' cannot be used with '--frozen')*
- `uv sync --extra dev --locked` *(fails: Unable to connect to pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_6903a7cf6c68832c846799508d0725b7