### PR TITLE
Cache lychee runs and tighten concurrency grouping

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,7 +1,7 @@
 name: Link Check (Lychee)
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: links-${{ github.ref }}
   cancel-in-progress: true
 
 on:
@@ -41,6 +41,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
 
+      - name: Setup cache for Lychee
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/lychee
+          key: lychee-${{ runner.os }}-${{ hashFiles('.lychee.toml') }}
+
       - name: Check links with Lychee
         id: lychee
         uses: lycheeverse/lychee-action@5b84becd9d3980d9d8716da68816c9bd1d4e0d96 # v2.1.0, stabiler Commit
@@ -61,7 +67,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment on PR if broken links
-        if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && steps.lychee.outputs.exit_code != 0 }}
+        if: >-
+          ${{ always()
+            && github.event_name == 'pull_request'
+            && github.event.pull_request.head.repo.fork == false
+            && steps.lychee.outcome != 'cancelled'
+            && steps.lychee.outputs.exit_code != ''
+            && steps.lychee.outputs.exit_code != '0' }}
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |
@@ -69,10 +81,14 @@ jobs:
             Exit Code: `${{ steps.lychee.outputs.exit_code }}`
             Siehe Artefakt: **lychee/out.md**
 
-      - name: Upload report artifact
-        if: ${{ always() && steps.lychee.outputs.exit_code != 0 && hashFiles('lychee/out.md') != '' }}
+      - name: Upload lychee report
+        if: >-
+          ${{ always()
+            && steps.lychee.outcome != 'cancelled'
+            && hashFiles('lychee/out.md') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: lychee-report
           path: lychee/out.md
+          if-no-files-found: error
           retention-days: 7


### PR DESCRIPTION
## Summary
- skip the PR comment when the lychee step is cancelled or omits an exit code
- upload the markdown report only when the lychee step completes and produces the file
- serialize workflow executions with a dedicated concurrency group
- cache the Lychee HTTP results directory to ease rate-limit pressure

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69047b6ef954832c9d2c9fa742975669