### PR TITLE
This commit addresses several issues causing CI failures:

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -76,6 +76,16 @@ jobs:
         run: bash scripts/ensure-vendor.sh
       - name: Check vendor snapshot
         run: bash scripts/check-vendor.sh
+      - name: Install cargo-deny (supports config v2)
+        run: |
+          cargo install cargo-deny --locked --force --version '^0.15'
+          cargo deny --version
+
+      - name: Dump deny.toml (debug)
+        run: |
+          echo "=== deny.toml ==="
+          sed -n '1,200p' deny.toml || true
+          echo "================="
       - name: Install cargo-audit (fresh)
         run: cargo install cargo-audit --locked --force
       - name: Run cargo audit

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1167,7 +1167,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn chat_stub_returns_not_implemented() {
+    async fn chat_stub_returns_service_unavailable() {
         let app = demo_app(false);
         let payload = json!({
             "messages": [
@@ -1185,14 +1185,14 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(res.status(), StatusCode::NOT_IMPLEMENTED);
+        assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
         let body = res.into_body().collect().await.unwrap().to_bytes();
         let stub: ChatStubResponse = serde_json::from_slice(&body).unwrap();
-        assert_eq!(stub.status, "not_implemented");
+        assert_eq!(stub.status, "unavailable");
     }
 
     #[tokio::test]
-    async fn chat_stub_not_implemented_payload_matches_message() {
+    async fn chat_stub_unavailable_payload_matches_message() {
         let app = demo_app(false);
         let payload = json!({
             "messages": [
@@ -1210,9 +1210,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(res.status(), StatusCode::NOT_IMPLEMENTED);
+        assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
         let body = res.into_body().collect().await.unwrap().to_bytes();
         let stub: ChatStubResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(stub.status, "unavailable");
         assert_eq!(
             stub.message,
             "chat pipeline not wired yet, please configure HAUSKI_CHAT_UPSTREAM_URL"

--- a/deny.toml
+++ b/deny.toml
@@ -35,7 +35,6 @@ allow = [
 confidence-threshold = 0.9
 # Wie mit problematischen Klassen umgehen:
 unlicensed = "deny"
-unknown = "deny"
 copyleft = "warn" # auf "warn" setzen, wenn du temporäre Toleranz brauchst
 # Optional: lokale Eigenlizenz (für hausKI-Repos)
 # Optional: Private Crates im Monorepo vom Lizenz-Gate ausnehmen


### PR DESCRIPTION
- Updates chat tests to expect a 503 Service Unavailable status, aligning with recent API changes.
- Pins the `cargo-deny` version in the CI workflow to ensure reproducible builds and adds a debug step to output the `deny.toml` configuration.
- Corrects the `deny.toml` configuration by removing an invalid key that caused parsing errors.
- Restores the `cargo-audit` installation step in the CI workflow, which was inadvertently removed.