### PR TITLE
fix: Correct Prometheus counter naming

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -132,7 +132,7 @@ impl AppState {
 
         let http_requests: Family<HttpLabels, Counter<u64>> = Family::default();
         registry.register(
-            "http_requests_total",
+            "http_requests",
             "Total number of HTTP requests received",
             http_requests.clone(),
         );
@@ -723,7 +723,7 @@ mod tests {
         let body = res.into_body().collect().await.unwrap().to_bytes();
         let text_one = String::from_utf8(body.to_vec()).unwrap();
 
-        let expected_health = r#"http_requests_total_total{method="GET",path="/health",status="200"} 1"#;
+        let expected_health = r#"http_requests_total{method="GET",path="/health",status="200"} 1"#;
         assert!(
             text_one.contains(expected_health),
             "metrics missing labeled health counter:\n{text_one}"
@@ -737,7 +737,7 @@ mod tests {
         let text_two = String::from_utf8(body.to_vec()).unwrap();
 
         let expected_metrics =
-            r#"http_requests_total_total{method="GET",path="/metrics",status="200"} 1"#;
+            r#"http_requests_total{method="GET",path="/metrics",status="200"} 1"#;
         assert!(
             text_two.contains(expected_metrics),
             "metrics missing labeled metrics counter:\n{text_two}"


### PR DESCRIPTION
The prometheus-client library automatically appends a "_total" suffix to counter metrics. By registering the "http_requests" counter as "http_requests_total", a double suffix ("_total_total") was being applied.

This change corrects the registration to "http_requests", which resolves the issue and fixes the failing "tests::metrics_include_index_search" test.

I also updated the "health_ok_and_metrics_increment" test to assert for the correct metric name.