### PR TITLE
fix(docs): Correct validation script path in events.md

### DIFF
--- a/docs/contracts/events.md
+++ b/docs/contracts/events.md
@@ -59,7 +59,7 @@ Für lokale Checks kann z. B. `jsonschema` (Python) oder jede Draft-2020-12-fäh
 uv run python - <<'PY'
 import json, sys, pathlib
 from jsonschema import validate, Draft202012Validator
-root = pathlib.Path(__file__).resolve().parents[1]
+root = pathlib.Path('.')
 schema = json.loads((root/"contracts/events.schema.json").read_text())
 sample = json.loads((root/"contracts/examples/event.sample.json").read_text())
 Draft202012Validator.check_schema(schema)


### PR DESCRIPTION
The validation script in the event schema documentation used `pathlib.Path(__file__)` to determine the project root. This fails when the script is executed via a heredoc, as is common in CI, because the `__file__` attribute is not defined in that context.

This change replaces the incorrect pathing logic with `pathlib.Path('.')`, which correctly references the current working directory. This aligns the documentation with the actual implementation in the CI workflow and ensures the example is runnable for users.