### PR TITLE
feat(hauski): Add playbook, dev tooling manifest, and CI validation

### DIFF
--- a/.dev/dev.tooling.json
+++ b/.dev/dev.tooling.json
@@ -1,0 +1,11 @@
+{
+ "$schema": "https://schemas.heimgewebe.org/dev.tooling.schema.json",
+ "language": "rust",
+ "lsp_config": { "rust_analyzer": { "cargo": { "buildScripts": true } } },
+ "code_generation": {
+ "templates": ["service", "cli"],
+ "generators": ["wgx.template"],
+ "validation_rules": ["fmt", "lint"]
+ },
+ "test_framework": { "kind": "cargo", "watch": true }
+}

--- a/.github/workflows/validate-dev-tooling.yml
+++ b/.github/workflows/validate-dev-tooling.yml
@@ -1,0 +1,16 @@
+name: validate-dev-tooling
+on:
+ pull_request:
+ paths: [".dev/dev.tooling.json"]
+ push:
+ paths: [".dev/dev.tooling.json"]
+jobs:
+ validate:
+ runs-on: ubuntu-latest
+ steps:
+ - uses: actions/checkout@8ade135a242bde00fd19c0e54fb3760beea110ee
+ - uses: actions/setup-node@5e221d4786ffb21088b21dfc9c80efb16b52cd3b
+ - run: npm i -g ajv-cli@5
+ - run: |
+ curl -fsSL https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/dev.tooling.schema.json -o /tmp/schema.json
+ ajv validate --spec=draft2020 --strict=true -s /tmp/schema.json -d .dev/dev.tooling.json

--- a/playbooks/ai_assist.yml
+++ b/playbooks/ai_assist.yml
@@ -1,0 +1,22 @@
+# ai_assist – Minimal-Playbook mit Gates
+version: 1
+name: ai_assist
+steps:
+ - id: gate_lint
+ run: |
+ if [[ -x ./scripts/wgx ]]; then
+ ./scripts/wgx code lint --fix || exit 1
+ else
+ echo "wgx fehlt – überspringe lint"; fi
+ - id: gate_knowledge_validate
+ run: |
+ npm i -g ajv-cli@5 >/dev/null 2>&1 || true
+ curl -fsSL https://raw.githubusercontent.com/heimgewebe/metarepo/contracts-v1/contracts/knowledge.graph.schema.json -o /tmp/schema.json
+ if [[ -f knowledge.graph.json ]]; then
+ ajv validate --spec=draft2020 -s /tmp/schema.json -d knowledge.graph.json
+ else
+ echo "no knowledge.graph.json – continue"
+ fi
+ - id: ai_assist
+ run: |
+ echo "→ AI Assist (placeholder) – hier z. B. Analyse/Refactor/Commit"


### PR DESCRIPTION
This commit introduces three new files:

* `playbooks/ai_assist.yml`: A playbook with gates for linting and knowledge validation before running AI assistance.
* `.dev/dev.tooling.json`: A manifest for development tooling.
* `.github/workflows/validate-dev-tooling.yml`: A CI workflow to validate the `dev.tooling.json` file against its schema.

These changes are based on the user's request to add a mini-playbook and CI gate.