### PR TITLE
hauski: add gated playbook and workflow

### DIFF
--- a/.github/workflows/playbook-gate.yml
+++ b/.github/workflows/playbook-gate.yml
@@ -1,0 +1,12 @@
+name: playbook-gate
+on:
+  pull_request:
+  workflow_dispatch: {}
+permissions: { contents: read }
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: just deps || true
+      - run: hauski run-playbook playbooks/code_assist.yml

--- a/playbooks/code_assist.yml
+++ b/playbooks/code_assist.yml
@@ -1,0 +1,12 @@
+version: 1
+name: code-assist-gated
+steps:
+- id: lint
+  run: "wgx code lint --export tmp/metrics.json"
+- id: kg-validate
+  run: |
+    wgx knowledge extract --repo . --out knowledge.graph.json
+    ./wgx knowledge validate --file knowledge.graph.json
+- id: ai-assist
+  needs: [lint, kg-validate]
+  run: "hauski assist --playbook code_review --metrics tmp/metrics.json --kg knowledge.graph.json"


### PR DESCRIPTION
Adds a new playbook `code_assist.yml` that runs linting and knowledge validation before triggering AI assistance.

Also adds a new GitHub Actions workflow `playbook-gate.yml` to run this playbook on pull requests.