### PR TITLE
fix(ci): build hauski binary before running playbook

### DIFF
--- a/.github/workflows/playbook-gate.yml
+++ b/.github/workflows/playbook-gate.yml
@@ -8,5 +8,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: just deps || true
-      - run: hauski run-playbook playbooks/code_assist.yml
+      - run: just build
+      - run: ./target/debug/hauski run-playbook playbooks/code_assist.yml


### PR DESCRIPTION
The playbook-gate workflow was failing with 'hauski: command not found' because it attempted to run the `hauski` command without first compiling the binary.

This change introduces a `just build` step to the workflow, which compiles the project, and then updates the execution command to run the binary from its output path `./target/debug/hauski`.