### PR TITLE
hauski: fix inconsistent wgx call in code_assist.yml

### DIFF
--- a/playbooks/code_assist.yml
+++ b/playbooks/code_assist.yml
@@ -6,7 +6,7 @@ steps:
 - id: kg-validate
   run: |
     wgx knowledge extract --repo . --out knowledge.graph.json
-    ./wgx knowledge validate --file knowledge.graph.json
+    wgx knowledge validate --file knowledge.graph.json
 - id: ai-assist
   needs: [lint, kg-validate]
   run: "hauski assist --playbook code_review --metrics tmp/metrics.json --kg knowledge.graph.json"


### PR DESCRIPTION
The 'kg-validate' step in 'playbooks/code_assist.yml' used both 'wgx' and './wgx' to call the wgx binary. This caused failures in environments where wgx is only available in the PATH.

This commit fixes the issue by consistently using 'wgx' for all calls to the binary.