### PR TITLE
ci: install just in playbook-gate workflow

### DIFF
--- a/.github/workflows/playbook-gate.yml
+++ b/.github/workflows/playbook-gate.yml
@@ -8,5 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install just
+        run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
       - run: just build
       - run: ./target/debug/hauski run-playbook playbooks/code_assist.yml


### PR DESCRIPTION
The playbook-gate workflow was failing because the 'just' command was not found. This change adds a step to install 'just' before it is used.