### PR TITLE
feat(memory): Add minimal hauski-memory core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "hauski-memory"
+version = "0.1.0"
+dependencies = [
+ "prometheus-client",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
 name = "hauski-policy-api"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/cli",
   "crates/embeddings",
   "crates/indexd",
+  "crates/memory",
   "crates/policy",
   "crates/policy_api",
   # weitere später: indexd, llm, asr, tts, audio, memory, commentary, bridge, observability, security, adapters/*
@@ -27,6 +28,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "tim
 axum = "0.8"
 clap = { version = "4", features = ["derive"] }
 prometheus-client = "0.24"
+prometheus-client-derive-encode = "0.5.0"
 walkdir = "2"
 dirs = "6.0.0"
 # Abhängigkeiten, die bereits von mehreren Crates genutzt werden, zentralisieren

--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "hauski-memory"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+prometheus-client = { workspace = true }
+prometheus-client-derive-encode = { workspace = true }

--- a/crates/memory/src/lib.rs
+++ b/crates/memory/src/lib.rs
@@ -1,0 +1,74 @@
+use std::hash::Hash;
+
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::counter::Counter;
+use prometheus_client::metrics::family::Family;
+
+/// Label-Set für Memory-Metriken.
+///
+/// WICHTIG: Für `Family<L, M>` müssen die Labels `Eq + Hash` implementieren
+/// und `EncodeLabelSet` liefern.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, EncodeLabelSet)]
+pub struct MemoryLabels {
+    pub namespace: String,
+    pub layer: String,
+}
+
+/// Minimaler Memory-Store nur für Metriken (A1).
+///
+/// A2 ersetzt/ergänzt dies um SQLite, TTL, Janitor & CRUD.
+#[derive(Default)]
+pub struct MemoryStore {
+    ops_total: Family<MemoryLabels, Counter>,
+}
+
+impl MemoryStore {
+    /// Erzeugt einen leeren Store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Zugriff auf die Metrik-Family zur Registrierung im Registry.
+    pub fn ops_family(&self) -> &Family<MemoryLabels, Counter> {
+        &self.ops_total
+    }
+
+    /// Erhöht einen Zähler für eine Operation in einem Namespace/Layer.
+    ///
+    /// Beispielverwendung im Core (A2): bei `set/get/evict` aufrufen.
+    pub fn touch<N, L>(&self, namespace: N, layer: L)
+    where
+        N: Into<String>,
+        L: Into<String>,
+    {
+        let labels = MemoryLabels {
+            namespace: namespace.into(),
+            layer: layer.into(),
+        };
+        let c = self.ops_total.get_or_create(&labels);
+        c.inc();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn labels_encode_ok() {
+        // Smoke-Test: compile-level assurance; runtime just ensures trait is callable.
+        let labels = MemoryLabels {
+            namespace: "default".to_string(),
+            layer: "short_term".to_string(),
+        };
+        // no-op: compile-time check is what we want here.
+        let _ = labels;
+    }
+
+    #[test]
+    fn family_get_or_create_and_inc() {
+        let store = MemoryStore::new();
+        store.touch("ns", "layer");
+        // If this compiles & runs without panic, Family<Labels, Counter> plumbing is good.
+    }
+}


### PR DESCRIPTION
This commit introduces the initial, minimal implementation of the `hauski-memory` crate.

This new crate provides a basic, in-memory store for metrics, laying the groundwork for future enhancements like SQLite-based persistence, TTL, and a janitor process.

Key changes include:
- A `MemoryLabels` struct for Prometheus metrics with `namespace` and `layer` dimensions.
- A `MemoryStore` with a `Family<MemoryLabels, Counter>` to track operations.
- The `EncodeLabelSet` trait is derived using `prometheus-client-derive-encode` for a clean and idiomatic implementation.

The crate is successfully added to the workspace and compiles cleanly.