### PR TITLE
feat(memory): implement SQLite-backed memory subsystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,15 @@ name = "anyhow"
 version = "1.0.100"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +230,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -286,6 +305,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,12 +338,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -403,6 +462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -505,6 +565,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +650,7 @@ dependencies = [
  "axum",
  "dirs",
  "hauski-indexd",
+ "hauski-memory",
  "http-body-util",
  "once_cell",
  "prometheus-client",
@@ -597,6 +668,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "utoipa",
+ "utoipa-swagger-ui",
  "walkdir",
 ]
 
@@ -626,8 +698,18 @@ dependencies = [
 name = "hauski-memory"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "chrono",
+ "dirs",
+ "once_cell",
  "prometheus-client",
- "prometheus-client-derive-encode",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "tempfile",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -996,6 +1078,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-rs-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1145,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1290,7 +1391,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1448,11 +1549,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
  "bitflags",
+ "chrono",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
+dependencies = [
+ "sha2",
+ "walkdir",
 ]
 
 [[package]]
@@ -1595,6 +1731,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +1802,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2059,8 +2219,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "ulid"
 version = "1.0.0"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -2073,6 +2245,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"
@@ -2113,6 +2291,7 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
+ "serde_norway",
  "utoipa-gen",
 ]
 
@@ -2129,6 +2308,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "axum",
+ "base64",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,6 +2336,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2613,4 +2816,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,15 +33,16 @@ walkdir = "2"
 dirs = "6.0.0"
 # Abhängigkeiten, die bereits von mehreren Crates genutzt werden, zentralisieren
 tower = "0.5"
-utoipa = { version = "5", features = ["axum_extras"] }
+utoipa = { version = "5.4", features = ["macros", "axum_extras", "yaml"] }
+utoipa-swagger-ui = { version = "9.0" }
 http-body-util = "0.1"
 serial_test = "3"
 tempfile = "3"
 # sqlx bewusst nicht vorgezogen, bis erste DB-Crate existiert
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots", "gzip"] }
 url = "2"
-rusqlite = { version = "0.37.0", features = ["bundled"] }
-chrono = { version = "0.4", features = ["clock"] }
+rusqlite = { version = "0.37.0", features = ["bundled", "chrono"] }
+chrono = { version = "0.4", features = ["clock", "serde"] }
 hostname = "0.4"
 ulid = "1"
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -23,7 +23,9 @@ reqwest.workspace = true
 url.workspace = true
 hauski-indexd = { path = "../indexd", version = "0.1.0" }
 tower = { workspace = true, features = ["limit", "timeout"] }
-utoipa.workspace = true
+utoipa = { workspace = true, features = ["macros"] }
+utoipa-swagger-ui = { workspace = true, features = ["axum"] }
+hauski-memory = { path = "../memory", version = "0.1.0" }
 
 [dev-dependencies]
 tower = { workspace = true, features = ["util"] }

--- a/crates/core/src/memory_api.rs
+++ b/crates/core/src/memory_api.rs
@@ -1,0 +1,134 @@
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::AppState;
+use hauski_memory as mem;
+
+#[derive(Debug, Deserialize, ToSchema)]
+#[schema(title = "MemoryGetRequest", example = json!({"key":"greeting"}))]
+pub struct MemoryGetRequest {
+    pub key: String,
+}
+#[derive(Debug, Serialize, ToSchema)]
+#[schema(title = "MemoryGetResponse", example = json!({"key":"greeting","value":"hi","ttl_sec":300,"pinned":false}))]
+pub struct MemoryGetResponse {
+    pub key: String,
+    pub value: Option<String>,
+    pub ttl_sec: Option<i64>,
+    pub pinned: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+#[schema(title = "MemorySetRequest", example = json!({"key":"greeting","value":"hi","ttl_sec":300,"pinned":false}))]
+pub struct MemorySetRequest {
+    pub key: String,
+    pub value: String,
+    #[serde(default)]
+    pub ttl_sec: Option<i64>,
+    #[serde(default)]
+    pub pinned: Option<bool>,
+}
+#[derive(Debug, Serialize, ToSchema)]
+#[schema(title = "MemorySetResponse", example = json!({"ok":true}))]
+pub struct MemorySetResponse {
+    pub ok: bool,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+#[schema(title = "MemoryEvictRequest", example = json!({"key":"greeting"}))]
+pub struct MemoryEvictRequest {
+    pub key: String,
+}
+#[derive(Debug, Serialize, ToSchema)]
+#[schema(title = "MemoryEvictResponse", example = json!({"ok":true}))]
+pub struct MemoryEvictResponse {
+    pub ok: bool,
+}
+
+#[utoipa::path(
+    post,
+    path = "/memory/get",
+    tag = "core",
+    request_body = MemoryGetRequest,
+    responses((status=200, body=MemoryGetResponse), (status=500, description="internal error"))
+)]
+pub async fn memory_get_handler(
+    _state: State<AppState>,
+    Json(req): Json<MemoryGetRequest>,
+) -> Response {
+    let store = mem::global();
+    match store.get(&req.key) {
+        Ok(Some(item)) => (
+            StatusCode::OK,
+            Json(MemoryGetResponse {
+                key: req.key,
+                value: Some(String::from_utf8_lossy(&item.value).into_owned()),
+                ttl_sec: item.ttl_sec,
+                pinned: Some(item.pinned),
+            }),
+        )
+            .into_response(),
+        Ok(None) => (
+            StatusCode::OK,
+            Json(MemoryGetResponse {
+                key: req.key,
+                value: None,
+                ttl_sec: None,
+                pinned: None,
+            }),
+        )
+            .into_response(),
+        Err(e) => {
+            tracing::error!(error = ?e, "failed to get memory item");
+            (StatusCode::INTERNAL_SERVER_ERROR).into_response()
+        }
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/memory/set",
+    tag = "core",
+    request_body = MemorySetRequest,
+    responses((status=200, body=MemorySetResponse), (status=500, description="internal error"))
+)]
+pub async fn memory_set_handler(
+    _state: State<AppState>,
+    Json(req): Json<MemorySetRequest>,
+) -> Response {
+    let store = mem::global();
+    match store.set(&req.key, req.value.as_bytes(), req.ttl_sec, req.pinned) {
+        Ok(_) => (StatusCode::OK, Json(MemorySetResponse { ok: true })).into_response(),
+        Err(e) => {
+            tracing::error!(error = ?e, "failed to set memory item");
+            (StatusCode::INTERNAL_SERVER_ERROR).into_response()
+        }
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/memory/evict",
+    tag = "core",
+    request_body = MemoryEvictRequest,
+    responses((status=200, body=MemoryEvictResponse), (status=500, description="internal error"))
+)]
+pub async fn memory_evict_handler(
+    _state: State<AppState>,
+    Json(req): Json<MemoryEvictRequest>,
+) -> Response {
+    let store = mem::global();
+    match store.evict(&req.key) {
+        Ok(ok) => (StatusCode::OK, Json(MemoryEvictResponse { ok })).into_response(),
+        Err(e) => {
+            tracing::error!(error = ?e, "failed to evict memory item");
+            (StatusCode::INTERNAL_SERVER_ERROR).into_response()
+        }
+    }
+}

--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -6,4 +6,16 @@ license = "MIT"
 
 [dependencies]
 prometheus-client = { workspace = true }
-prometheus-client-derive-encode = { workspace = true }
+tracing = { workspace = true }
+anyhow = { workspace = true }
+chrono = { workspace = true }
+rusqlite = { workspace = true }
+dirs = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+once_cell = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+serial_test = { workspace = true }

--- a/crates/memory/src/lib.rs
+++ b/crates/memory/src/lib.rs
@@ -1,74 +1,281 @@
-use std::hash::Hash;
+use std::{borrow::Cow, fmt, hash::Hash, path::PathBuf, time::Duration};
 
-use prometheus_client::encoding::EncodeLabelSet;
-use prometheus_client::metrics::counter::Counter;
-use prometheus_client::metrics::family::Family;
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use once_cell::sync::OnceCell;
+use prometheus_client::{
+    encoding::{EncodeLabelSet, LabelSetEncoder},
+    metrics::{counter::Counter, family::Family},
+};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use tokio::task::JoinHandle;
 
-/// Label-Set für Memory-Metriken.
-///
-/// WICHTIG: Für `Family<L, M>` müssen die Labels `Eq + Hash` implementieren
-/// und `EncodeLabelSet` liefern.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, EncodeLabelSet)]
-pub struct MemoryLabels {
-    pub namespace: String,
-    pub layer: String,
+// ---------- Metrik-Labels (bleiben wie in A1) ----------
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct MemoryLabels<'a> {
+    pub namespace: Cow<'a, str>,
+    pub layer: Cow<'a, str>,
+}
+impl<'a> EncodeLabelSet for MemoryLabels<'a> {
+    fn encode(&self, encoder: &mut LabelSetEncoder) -> fmt::Result {
+        use prometheus_client::encoding::EncodeLabel;
+        ("namespace", self.namespace.as_ref()).encode(encoder.encode_label())?;
+        ("layer", self.layer.as_ref()).encode(encoder.encode_label())?;
+        Ok(())
+    }
 }
 
-/// Minimaler Memory-Store nur für Metriken (A1).
-///
-/// A2 ersetzt/ergänzt dies um SQLite, TTL, Janitor & CRUD.
-#[derive(Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct EvictLabels<'a> {
+    pub reason: Cow<'a, str>, // "expired" | "manual"
+}
+impl<'a> EncodeLabelSet for EvictLabels<'a> {
+    fn encode(&self, encoder: &mut LabelSetEncoder) -> fmt::Result {
+        use prometheus_client::encoding::EncodeLabel;
+        ("reason", self.reason.as_ref()).encode(encoder.encode_label())?;
+        Ok(())
+    }
+}
+
+// ---------- Public API ----------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Item {
+    pub key: String,
+    pub value: Vec<u8>,
+    pub ttl_sec: Option<i64>,
+    pub pinned: bool,
+    pub created_ts: DateTime<Utc>,
+    pub updated_ts: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct MemoryConfig {
+    /// Optionaler Pfad zur DB-Datei. Default: $XDG_STATE_HOME/hauski/memory.db
+    pub db_path: Option<PathBuf>,
+    /// Janitor-Intervall in Sekunden (Default 60).
+    pub janitor_interval_secs: u64,
+}
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        Self {
+            db_path: None,
+            janitor_interval_secs: 60,
+        }
+    }
+}
+
 pub struct MemoryStore {
-    ops_total: Family<MemoryLabels, Counter>,
+    pub(crate) db_path: PathBuf,
+    // Metriken (werden in A3 an die Core-Registry gehängt)
+    pub(crate) ops_total: Family<MemoryLabels<'static>, Counter>,
+    pub(crate) evictions_total: Family<EvictLabels<'static>, Counter>,
+    pub(crate) _janitor: JoinHandle<()>,
+}
+
+static GLOBAL: OnceCell<MemoryStore> = OnceCell::new();
+
+pub fn init_default() -> Result<&'static MemoryStore> {
+    init_with(MemoryConfig::default())
+}
+
+pub fn init_with(cfg: MemoryConfig) -> Result<&'static MemoryStore> {
+    let base = dirs::state_dir().unwrap_or_else(|| {
+        // Fallback in $HOME/.local/state
+        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+        home.join(".local/state")
+    });
+    let db_path = cfg.db_path.unwrap_or_else(|| base.join("hauski").join("memory.db"));
+    std::fs::create_dir_all(db_path.parent().unwrap())
+        .with_context(|| format!("create parent dir for {:?}", db_path))?;
+
+    // ensure schema exists
+    {
+        let conn = Connection::open(&db_path)
+            .with_context(|| format!("open sqlite at {:?}", db_path))?;
+        conn.execute_batch(
+            r#"
+            PRAGMA journal_mode=WAL;
+            CREATE TABLE IF NOT EXISTS memory_items(
+                key TEXT PRIMARY KEY,
+                value BLOB NOT NULL,
+                ttl_sec INTEGER NULL,
+                pinned INTEGER NOT NULL DEFAULT 0,
+                created_ts TEXT NOT NULL,
+                updated_ts TEXT NOT NULL
+            );
+            "#,
+        )?;
+    }
+
+    // spawn janitor
+    let interval = cfg.janitor_interval_secs.max(5);
+    let jp = tokio::spawn(janitor_task(db_path.clone(), interval));
+
+    let store = MemoryStore {
+        db_path,
+        ops_total: Family::default(),
+        evictions_total: Family::default(),
+        _janitor: jp,
+    };
+    Ok(GLOBAL.get_or_init(|| store))
+}
+
+pub fn global() -> &'static MemoryStore {
+    GLOBAL.get().expect("hauski-memory not initialized; call init_default() early")
 }
 
 impl MemoryStore {
-    /// Erzeugt einen leeren Store.
-    pub fn new() -> Self {
-        Self::default()
-    }
+    pub fn set(&self, key: &str, value: &[u8], ttl_sec: Option<i64>, pinned: Option<bool>) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        let pinned_i = if pinned.unwrap_or(false) { 1 } else { 0 };
+        let conn = Connection::open(&self.db_path)?;
 
-    /// Zugriff auf die Metrik-Family zur Registrierung im Registry.
-    pub fn ops_family(&self) -> &Family<MemoryLabels, Counter> {
-        &self.ops_total
-    }
+        // Bewahre created_ts, wenn vorhanden; sonst jetzt
+        let created: Option<String> = conn
+            .query_row(
+                "SELECT created_ts FROM memory_items WHERE key=?1",
+                params![key],
+                |r| r.get(0),
+            )
+            .optional()?;
+        let created_ts = created.unwrap_or_else(|| now.clone());
 
-    /// Erhöht einen Zähler für eine Operation in einem Namespace/Layer.
-    ///
-    /// Beispielverwendung im Core (A2): bei `set/get/evict` aufrufen.
-    pub fn touch<N, L>(&self, namespace: N, layer: L)
-    where
-        N: Into<String>,
-        L: Into<String>,
-    {
-        let labels = MemoryLabels {
-            namespace: namespace.into(),
-            layer: layer.into(),
-        };
-        let c = self.ops_total.get_or_create(&labels);
+        conn.execute(
+            r#"INSERT INTO memory_items(key,value,ttl_sec,pinned,created_ts,updated_ts)
+                VALUES (?1,?2,?3,?4,?5,?6)
+                ON CONFLICT(key) DO UPDATE SET
+                    value=excluded.value,
+                    ttl_sec=excluded.ttl_sec,
+                    pinned=excluded.pinned,
+                    updated_ts=excluded.updated_ts;"#,
+            params![key, value, ttl_sec, pinned_i, created_ts, now],
+        )?;
+
+        let c = self.ops_total.get_or_create(&MemoryLabels{ namespace: Cow::Borrowed("default"), layer: Cow::Borrowed("short_term")});
         c.inc();
+        Ok(())
+    }
+
+    pub fn get(&self, key: &str) -> Result<Option<Item>> {
+        let conn = Connection::open(&self.db_path)?;
+        let row = conn
+            .query_row(
+                r#"SELECT key, value, ttl_sec, pinned, created_ts, updated_ts
+                    FROM memory_items WHERE key=?1"#,
+                params![key],
+                |r| {
+                    let pinned_i: i64 = r.get(3)?;
+                    let created: String = r.get(4)?;
+                    let updated: String = r.get(5)?;
+                    Ok(Item {
+                        key: r.get(0)?,
+                        value: r.get(1)?,
+                        ttl_sec: r.get(2)?,
+                        pinned: pinned_i != 0,
+                        created_ts: created.parse().unwrap_or_else(|e| {
+                            tracing::warn!(error = ?e, "failed to parse created_ts");
+                            Utc::now()
+                        }),
+                        updated_ts: updated.parse().unwrap_or_else(|e| {
+                            tracing::warn!(error = ?e, "failed to parse updated_ts");
+                            Utc::now()
+                        }),
+                    })
+                },
+            )
+            .optional()?;
+
+        let c = self.ops_total.get_or_create(&MemoryLabels{ namespace: Cow::Borrowed("default"), layer: Cow::Borrowed("short_term")});
+        c.inc();
+        Ok(row)
+    }
+
+    pub fn evict(&self, key: &str) -> Result<bool> {
+        let conn = Connection::open(&self.db_path)?;
+        let n = conn.execute("DELETE FROM memory_items WHERE key=?1", params![key])?;
+        if n > 0 {
+            let c = self.evictions_total.get_or_create(&EvictLabels{ reason: Cow::Borrowed("manual") });
+            c.inc();
+        }
+        Ok(n > 0)
+    }
+}
+
+async fn janitor_task(db_path: PathBuf, every_secs: u64) {
+    let d = Duration::from_secs(every_secs);
+    loop {
+        tokio::time::sleep(d).await;
+        if let Ok(conn) = Connection::open(&db_path) {
+            // Lösche abgelaufene TTLs, wenn nicht gepinnt
+            let _ = conn.execute(
+                r#"DELETE FROM memory_items
+                    WHERE pinned=0
+                        AND ttl_sec IS NOT NULL
+                        AND (strftime('%s','now') - strftime('%s', updated_ts)) > ttl_sec"#,
+                [],
+            );
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
-    #[test]
-    fn labels_encode_ok() {
-        // Smoke-Test: compile-level assurance; runtime just ensures trait is callable.
-        let labels = MemoryLabels {
-            namespace: "default".to_string(),
-            layer: "short_term".to_string(),
+    /// Test-interne Hilfsfunktion, die einen isolierten Store für jeden Test erstellt.
+    /// Gibt den Store und das TempDir zurück, um dessen Lebensdauer an den Test zu binden.
+    fn test_store(janitor_interval_secs: u64) -> (MemoryStore, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("m.db");
+
+        // Schema-Erstellung (wie in init_with)
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                r#"
+                PRAGMA journal_mode=WAL;
+                CREATE TABLE IF NOT EXISTS memory_items(
+                    key TEXT PRIMARY KEY, value BLOB NOT NULL, ttl_sec INTEGER NULL,
+                    pinned INTEGER NOT NULL DEFAULT 0, created_ts TEXT NOT NULL, updated_ts TEXT NOT NULL
+                );"#,
+            )
+            .unwrap();
+        }
+
+        let jp = tokio::spawn(janitor_task(db_path.clone(), janitor_interval_secs));
+
+        let store = MemoryStore {
+            db_path,
+            ops_total: Family::default(),
+            evictions_total: Family::default(),
+            _janitor: jp,
         };
-        // no-op: compile-time check is what we want here.
-        let _ = labels;
+        (store, tmp)
     }
 
-    #[test]
-    fn family_get_or_create_and_inc() {
-        let store = MemoryStore::new();
-        store.touch("ns", "layer");
-        // If this compiles & runs without panic, Family<Labels, Counter> plumbing is good.
+    #[tokio::test]
+    async fn set_get_evict_roundtrip() {
+        let (store, _tmp) = test_store(60);
+        store.set("k", "v".as_bytes(), Some(5), Some(false)).unwrap();
+        let it = store.get("k").unwrap().unwrap();
+        assert_eq!(it.key, "k");
+        assert_eq!(it.value, b"v");
+        assert!(store.evict("k").unwrap());
+        assert!(store.get("k").unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn janitor_expires() {
+        let (store, _tmp) = test_store(1);
+        store.set("k", "v".as_bytes(), Some(1), Some(false)).unwrap();
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        // allow janitor to run
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let got = store.get("k").unwrap();
+        assert!(got.is_none(), "expected TTL expiry");
     }
 }

--- a/docs/modules/memory.md
+++ b/docs/modules/memory.md
@@ -1,29 +1,16 @@
-# Memory
+# Memory (SQLite + TTL, MVP)
 
-Die Memory-Schicht verwaltet Kontextwissen über mehrere Zeithorizonte. Sie ist im Stack als eigener Crate vorgesehen und kapselt Retrieval-Policies gegenüber `core` und `indexd`.
+Ein schlanker Key/Value-Speicher mit optionalem TTL und Pin-Flag.
+Nur sichtbar, wenn `HAUSKI_EXPOSE_CONFIG=true`.
 
-## Designziele
+## Endpunkte
 
-- **Schichtenmodell:** Kurzzeit- („short“), Arbeits- („working“) und Langzeitspeicher („long“) mit separaten TTLs und Pin-Optionen.
-- **Policy-gesteuert:** `policies/memory.yaml` definiert Aufbewahrung, Prioritäten und Grenzwerte pro Layer.
-- **Hot/Cold-Split:** Relevante Kontexte landen im In-Memory-Index (`indexd`), kalte Daten werden in SQLite oder Files persistiert.
-- **Budget-Awareness:** Jeder Abruf respektiert die in `limits.yaml` hinterlegten p95-Vorgaben.
+| Route            | Methode | Body                                                           | Antwort                                                          |
+|------------------|--------:|----------------------------------------------------------------|------------------------------------------------------------------|
+| `/memory/get`    | POST    | `{ "key": "..." }`                                             | `{ "key":"...", "value": "...", "ttl_sec": 300, "pinned": false }` |
+| `/memory/set`    | POST    | `{ "key":"...", "value":"...", "ttl_sec":300, "pinned":false }` | `{ "ok": true }`                                                 |
+| `/memory/evict`  | POST    | `{ "key":"..." }`                                              | `{ "ok": true }`                                                 |
 
-## Schnittstellen (geplant)
+**TTL-Janitor:** löscht alle 60s Einträge, deren `updated_ts + ttl_sec` überschritten ist und `pinned=0`.
 
-| Funktion | Beschreibung |
-| --- | --- |
-| `record_interaction(event)` | Speichert neue Interaktions- oder Analyseartefakte unter Berücksichtigung der Routing-Policy. |
-| `fetch_context(query, budget)` | Liefert Kontext-Chunks für LLM-Aufrufe, inklusive Score und Herkunftslayer. |
-| `pin(item_id, layer)` | Markiert Elemente als unantastbar trotz TTL. |
-| `expire()` | Hintergrundjob für TTL-Löschungen und Budgetbereinigung. |
-
-## Zusammenspiel mit anderen Modulen
-
-- **Core:** ruft Memory-APIs auf, bevor `/ask` beantwortet wird, und entscheidet anhand der Scores über Prompt-Injektion.
-- **Indexd:** dient als schneller Retrieval-Store für „working“-Kontexte; Memory synchronisiert relevante Chunks dorthin.
-- **Policies:** Memory respektiert Routing- und Limit-Policies, um Egress- oder Token-Budgets nicht zu verletzen.
-
-## Implementierungsstand
-
-Der Crate ist im Workspace vorgesehen, aber noch nicht implementiert. Die Architektur-Dokumente bilden den Fahrplan – sobald Memory gebaut wird, sollten Unit-Tests für TTL/Pinning sowie Integrationstests gegen `indexd` ergänzt werden.
+**Werteformat:** `value` wird als UTF-8 String übertragen und intern als `BLOB` gespeichert.


### PR DESCRIPTION
Adds a new `hauski-memory` crate that provides a key-value store with SQLite for persistence.

Features:
- SQLite-backed persistence for durability.
- Optional TTL on items with a background janitor task for cleanup.
- A simple CRUD HTTP API exposed at `/memory/*`.
- API and documentation are only exposed when `HAUSKI_EXPOSE_CONFIG=true`.
- Includes unit tests with proper isolation to prevent race conditions.
- Robust error handling in the API layer.