### PR TITLE
hauski: fix playbook-gate.yml workflow

### DIFF
--- a/.github/workflows/playbook-gate.yml
+++ b/.github/workflows/playbook-gate.yml
@@ -10,5 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install just
         run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
-      - run: just build
-      - run: ./target/debug/hauski run-playbook playbooks/code_assist.yml
+      - name: Build hauski binary
+        run: cargo build --package hauski-cli --release
+      - name: Run playbook
+        run: ./target/release/hauski-cli run-playbook playbooks/code_assist.yml


### PR DESCRIPTION
The playbook-gate.yml workflow was failing because it was trying to execute the `hauski` binary before it was built.

This commit fixes the workflow by adding a build step that compiles the `hauski-cli` crate in release mode. The `run` step is also updated to use the correct path to the compiled binary.