### PR TITLE
hauski: fix(ci): Correct playbook command in CI workflow

### DIFF
--- a/.github/workflows/playbook-gate.yml
+++ b/.github/workflows/playbook-gate.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Build hauski binary
         run: cargo build --package hauski-cli --release
       - name: Run playbook
-        run: ./target/release/hauski-cli run-playbook playbooks/code_assist.yml
+        run: ./target/release/hauski-cli assist --playbook playbooks/code_assist.yml


### PR DESCRIPTION
The playbook-gate workflow was failing due to an unrecognized subcommand 'run-playbook' for the hauski-cli tool.

This commit updates the workflow to use the correct command 'assist --playbook', as indicated by the playbook's own definition.