### PR TITLE
feat(memory): Introduce TTL and pin policy

### DIFF
--- a/docs/modules/memory.md
+++ b/docs/modules/memory.md
@@ -14,3 +14,21 @@ Nur sichtbar, wenn `HAUSKI_EXPOSE_CONFIG=true`.
 **TTL-Janitor:** löscht alle 60s Einträge, deren `updated_ts + ttl_sec` überschritten ist und `pinned=0`.
 
 **Werteformat:** `value` wird als UTF-8 String übertragen und intern als `BLOB` gespeichert.
+
+## Policy
+
+Optionale Datei `policies/memory.yaml`:
+
+```yaml
+default_ttl_sec: 300
+pin_allowlist:
+  - "session:*"
+  - "profile:current_user"
+```
+
+Semantik:
+- **default_ttl_sec** wird angewendet, wenn `/memory/set` keinen `ttl_sec` enthält.
+- **pin_allowlist** setzt `pinned=true`, wenn `/memory/set` kein `pinned` liefert und der `key` passt.
+  Eintrag der Form `prefix:*` matcht per Präfix.
+
+Override-Pfad via `HAUSKI_MEMORY_POLICY_PATH`.

--- a/policies/memory.yaml
+++ b/policies/memory.yaml
@@ -1,0 +1,13 @@
+# Default-Policy für das Memory-Subsystem.
+# Diese Datei ist optional. Wenn vorhanden, wird sie beim Core-Start (bzw.
+# beim ersten Memory-API-Aufruf) eingelesen.
+#
+# Semantik:
+# - default_ttl_sec: Wird verwendet, wenn /memory/set keinen ttl_sec liefert.
+# - pin_allowlist: Keys, die automatisch als pinned=true gesetzt werden,
+#   wenn der Request kein pinned-Feld enthält.
+
+default_ttl_sec: 300
+pin_allowlist:
+  - "session:*"
+  - "profile:current_user"


### PR DESCRIPTION
Adds a `policies/memory.yaml` file to define a default TTL and a pin allowlist for the memory subsystem.

The `/memory/set` API handler now consults this policy. If a request does not specify `ttl_sec` or `pinned`, the values from the policy are used as defaults.

The `pin_allowlist` supports exact key matching and prefix matching (e.g., "session:*") to automatically pin specific keys.

The documentation has been updated to reflect this new functionality.