### PR TITLE
hauski: ci(playbook-gate): Install wgx before use

### DIFF
--- a/.github/workflows/playbook-gate.yml
+++ b/.github/workflows/playbook-gate.yml
@@ -8,6 +8,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo + target
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ runner.os }}-wgx-${{ hashFiles('**/Cargo.lock') }}
+          cache-on-failure: true
+
+      - name: Add Cargo bin to PATH
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Install wgx (via cargo)
+        run: |
+          if ! command -v wgx >/dev/null 2>&1; then
+            cargo install --locked --git https://github.com/heimgewebe/wgx wgx
+          fi
+          wgx --version
+
       - name: Install just
         run: curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
       - name: Build hauski binary


### PR DESCRIPTION
The `playbook-gate` workflow was failing with a `sh: 1: wgx: not found` error because the `wgx` tool was not installed on the GitHub Actions runner.

This commit fixes the issue by adding the necessary steps to the workflow to install `wgx` using `cargo install` before it is called. It also adds a caching step for Cargo to improve performance. This follows the robust installation pattern provided by the user.