### PR TITLE
fix(core): map serde_json error in assist event writer

### DIFF
--- a/crates/core/src/assist.rs
+++ b/crates/core/src/assist.rs
@@ -89,7 +89,8 @@ fn write_event(kind: &str, level: &str, labels: BTreeMap<&str, serde_json::Value
         let p = Path::new(&path);
         if let Some(dir) = p.parent() { fs::create_dir_all(dir)?; }
         let mut f = fs::OpenOptions::new().create(true).append(true).open(p)?;
-        serde_json::to_writer(&mut f, &event)?;
+        serde_json::to_writer(&mut f, &event)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
         f.write_all(b"\n")?;
         Ok(())
     })() {


### PR DESCRIPTION
The `write_event` function in `crates/core/src/assist.rs` was failing to compile because `serde_json::to_writer` returns a `serde_json::Error`, but the surrounding closure expected a `std::io::Error`.

This change maps the `serde_json::Error` to a `std::io::Error` using `map_err`, allowing the error to be correctly propagated and fixing the build.