### PR TITLE
hauski: implement top-k search for knowledge assist

### DIFF
--- a/docs/modules/assist.md
+++ b/docs/modules/assist.md
@@ -29,6 +29,7 @@ In Phase-2 dient dies als Gerüst, um später semantAH-Suche, Tools und Policies
 | Variable | Default | Zweck |
 | --- | --- | --- |
 | `HAUSKI_EVENT_SINK` | _(leer)_ | Wenn gesetzt, werden Events (JSONL) hierhin angehängt. |
++| `HAUSKI_INTERNAL_BASE` | `http://127.0.0.1:8080` | Basis-URL für interne HTTP-Aufrufe (hier: `/index/search`). |
 
 ## Nächste Schritte
 - Knowledge-Agent mit **semantAH Top-K** und Zitaten anbinden (füllt `citations[]` mit Titeln/IDs & Scores).


### PR DESCRIPTION
This commit enhances the /assist endpoint's "knowledge" path.

- It replaces the MVP stub with a live HTTP POST request to the /index/search endpoint to fetch the top-K citations for a given question.
- The integration is designed to be resilient, gracefully falling back to an empty citation list if the index service is unavailable or returns an incompatible schema.
- Configuration is provided via the `HAUSKI_INTERNAL_BASE` environment variable.
- Documentation for this new environment variable has been added to `docs/modules/assist.md`.