### PR TITLE
hauski: fix(ci): Install wgx by cloning instead of cargo install

### DIFF
--- a/.github/workflows/playbook-gate.yml
+++ b/.github/workflows/playbook-gate.yml
@@ -23,10 +23,11 @@ jobs:
       - name: Add Cargo bin to PATH
         run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
-      - name: Install wgx (via cargo)
+      - name: Install wgx (from git)
         run: |
           if ! command -v wgx >/dev/null 2>&1; then
-            cargo install --locked --git https://github.com/heimgewebe/wgx wgx
+            git clone https://github.com/heimgewebe/wgx.git /tmp/wgx
+            echo "/tmp/wgx/bin" >> "$GITHUB_PATH"
           fi
           wgx --version
 


### PR DESCRIPTION
The wgx tool is a shell-based utility, not a Rust crate, and therefore cannot be installed with `cargo install`.

This commit changes the playbook-gate workflow to clone the `wgx` repository directly from GitHub and add its `bin` directory to the `PATH`, ensuring the tool is available for subsequent steps.