### PR TITLE
hauski: fix(ci): Make wgx available in PATH immediately

### DIFF
--- a/.github/workflows/playbook-gate.yml
+++ b/.github/workflows/playbook-gate.yml
@@ -28,6 +28,7 @@ jobs:
           if ! command -v wgx >/dev/null 2>&1; then
             git clone https://github.com/heimgewebe/wgx.git /tmp/wgx
             echo "/tmp/wgx/bin" >> "$GITHUB_PATH"
+            export PATH="/tmp/wgx/bin:$PATH"
           fi
           wgx --version
 


### PR DESCRIPTION
In the playbook-gate workflow, the `wgx` binary was being called in the same step that its path was being added to `GITHUB_PATH`. This caused the `wgx --version` command to fail because `GITHUB_PATH` updates only take effect in subsequent steps.

This commit fixes the issue by also exporting the `wgx` binary's path to the current shell's `PATH` environment variable. This makes the binary immediately available and ensures that the version check passes.