### PR TITLE
feat(assist): implement code agent stub with 501 response

### DIFF
--- a/docs/modules/assist.md
+++ b/docs/modules/assist.md
@@ -24,6 +24,24 @@ In Phase-2 dient dies als Gerüst, um später semantAH-Suche, Tools und Policies
 
 > Der `mode`-Parameter ist optional. Wenn gesetzt (`code|knowledge`), überschreibt er die Heuristik.
 
+### Code-Pfad (Stub)
+Bis der Code-Agent angebunden ist, liefert der Router für `mode=code` (oder heuristisch erkannten Code)
+einen `501 Not Implemented` mit kurzer Diagnose im `trace`:
+```json
+{
+  "answer": "CodeAgent ist noch nicht verdrahtet (501).",
+  "citations": [],
+  "trace": [{
+    "step":"code_stub",
+    "decision":"code",
+    "language_guess":"python",
+    "next":"not_implemented",
+    "advice":"Prüfe Traceback-Root-Cause; venv/uv nutzen, Abhängigkeiten synchronisieren."
+  }],
+  "latency_ms": 7
+}
+```
+
 ## Konfiguration
 
 | Variable | Default | Zweck |


### PR DESCRIPTION
The /assist endpoint now handles the "code" path by returning a 501 Not Implemented status.

The response includes a structured diagnostic trace with a language guess and advice.

The OpenAPI specification and user documentation have been updated to reflect this change.