### PR TITLE
feat(assist): add rate limiting and feature gate to /assist

### DIFF
--- a/docs/modules/assist.md
+++ b/docs/modules/assist.md
@@ -53,3 +53,10 @@ einen `501 Not Implemented` mit kurzer Diagnose im `trace`:
 - Knowledge-Agent mit **semantAH Top-K** und Zitaten anbinden (füllt `citations[]` mit Titeln/IDs & Scores).
 - Code-Agent: Lint/Build/Run-Tools und Kurzdiagnosen.
 - Events (`core.assist.request|response`) nach `contracts/events.schema.json`.
+
+## Guards & Limits
+
+| Variable | Default | Zweck |
+| --- | --- | --- |
+| `HAUSKI_ASSIST_ENABLED` | `true` | Globales Feature-Gate. Wenn `false`, liefert `/assist` `503`. |
+| `HAUSKI_ASSIST_MAX_PER_MIN` | `60` | Globales Prozess-Limit (Requests/Minute). Bei Überschreitung `429` mit `trace.retry_after_sec`. |


### PR DESCRIPTION
Adds a process-wide rate limiter and a feature flag to the `/assist` endpoint, configurable via environment variables.

- `HAUSKI_ASSIST_MAX_PER_MIN` (default: 60): Sets the maximum number of requests per minute. Exceeding this limit returns a `429 Too Many Requests` error.
- `HAUSKI_ASSIST_ENABLED` (default: true): A feature flag to enable or disable the endpoint. When disabled, the endpoint returns a `503 Service Unavailable` error.

Both error responses include a `retry_after_sec` field in the JSON trace for client-side handling.

The OpenAPI documentation has been updated to reflect the new `429` and `503` responses, and the user-facing documentation has been updated with the new environment variables.