### PR TITLE
feat(ci): add security baseline with dependabot and gitleaks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,15 @@
 version: 2
 updates:
+  # Halte CI-Actions aktuell (Sicherheitsfixes)
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    schedule: { interval: "weekly" }
   - package-ecosystem: "cargo"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    schedule: { interval: "weekly" }
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule: { interval: "weekly" }
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule: { interval: "weekly" }

--- a/.github/workflows/secret-scan-gitleaks.yml
+++ b/.github/workflows/secret-scan-gitleaks.yml
@@ -1,0 +1,32 @@
+name: secret-scan-gitleaks
+
+# Minimale Berechtigungen – keine Schreibrechte
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+  pull_request: {}
+  schedule:
+    - cron: "13 4 * * 1" # jeden Montag 04:13 UTC
+
+concurrency:
+  group: secret-scan-gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Gitleaks (Lizenz über Secret)
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+        with:
+          args: "--no-banner --redact --exit-code 1"


### PR DESCRIPTION
- Adds a Dependabot configuration to check for weekly updates for Cargo, NPM, Pip, and GitHub Actions.
- Adds a Gitleaks workflow to scan for secrets on pushes, pull requests, and on a weekly schedule.
- The Gitleaks workflow uses a `GITLEAKS_LICENSE` secret and has minimal read-only permissions.