### PR TITLE
chore(github): restore secret_scanning.yml

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,12 @@
+# Ignore vendored test fixtures & examples to avoid false positives
+# (z.B. Test-Keys in Dependencies). Wir löschen nichts aus vendor/,
+# damit Cargo-Checksummen intakt bleiben.
+paths-ignore:
+- "vendor/**/tests/**"
+- "vendor/**/testdata/**"
+- "vendor/**/fixtures/**"
+- "vendor/**/examples/**"
+- "vendor/**/example/**"
+
+# Optional: eigene Pfade für lokale Tests/Demos
+# - "crates/**/tests/fixtures/**"


### PR DESCRIPTION
Restores the `secret_scanning.yml` file that was accidentally deleted. This file is crucial for preventing false positives from vendored test fixtures during secret scanning.