### PR TITLE
docs(heimgewebe): Rename leitstand to chronik

### DIFF
--- a/docs/audit-hauski.md
+++ b/docs/audit-hauski.md
@@ -30,7 +30,7 @@ Dieses Dokument ergänzt die bestehende Analyse durch gezielte Empfehlungen zur 
         - run: bash scripts/check-vendor.sh
   ```
 
-  So können alle Repos (`heimlern`, `leitstand`, `aussensensor`) denselben Check einbinden.
+  So können alle Repos (`heimlern`, `chronik`, `aussensensor`) denselben Check einbinden. Der Name "Leitstand" ist zukünftig für das zentrale UI/Dashboard vorgesehen.
 
 ## 3. Review-Zyklus in CI einbinden
 - Die hausKI-spezifische Review-Pipeline (`.hauski-reports`, `flock`, `hauski-reviewd`) sollte einen optionalen CI-Workflow auslösen:

--- a/docs/modules/policy.md
+++ b/docs/modules/policy.md
@@ -17,7 +17,7 @@ Es stellt eine gemeinsame Policy-Engine für hausKI-Komponenten bereit.
 
 - Validieren von Konfigurationen gegen Policies
 - Laufzeitprüfung (Budget-Überwachung)
-- Bereitstellen strukturierter Policy-Events für `leitstand`
+- Bereitstellen strukturierter Policy-Events für `chronik` (den Event-Store)
 
 ---
 

--- a/heimgewebe-.ai-context.yml-sammlung/aussensensor.ai-context.yml
+++ b/heimgewebe-.ai-context.yml-sammlung/aussensensor.ai-context.yml
@@ -2,14 +2,14 @@ ai_context_version: 1.0
 
 project:
   name: aussensensor
-  summary: Scripted data collection pushing events to leitstand.
+  summary: Scripted data collection pushing events to chronik.
   role: sensor_event_producer
   primary_language: bash
   visibility: internal
 
 dependencies:
   internal:
-    - name: leitstand
+    - name: chronik
       relationship: uses
       interface:
         - http_ingest_aussen
@@ -30,7 +30,7 @@ architecture:
   data_flow:
     input: polling / external sensors
     processing: map to contract shape
-    output: POST to leitstand ingest
+    output: POST to chronik ingest
 
 conventions:
   branching: "main, feature/*"

--- a/heimgewebe-.ai-context.yml-sammlung/chronik.ai-context.yml
+++ b/heimgewebe-.ai-context.yml-sammlung/chronik.ai-context.yml
@@ -1,7 +1,7 @@
 ai_context_version: 1.0
 
 project:
-  name: leitstand
+  name: chronik
   summary: Event ingest and processing hub.
   role: central_event_store
   primary_language: rust
@@ -36,7 +36,7 @@ architecture:
 
 conventions:
   branching: "main, feature/*, hotfix/*"
-  commit_prefix: "leitstand"
+  commit_prefix: "chronik"
   ci_platform: github_actions
 
 documentation:

--- a/heimgewebe-.ai-context.yml-sammlung/hauski-audio.ai-context.yml
+++ b/heimgewebe-.ai-context.yml-sammlung/hauski-audio.ai-context.yml
@@ -13,7 +13,7 @@ dependencies:
       relationship: uses
       interface:
         - audio_events_schema
-    - name: leitstand
+    - name: chronik
       relationship: uses
       interface:
         - event_ingest

--- a/heimgewebe-.ai-context.yml-sammlung/heimlern.ai-context.yml
+++ b/heimgewebe-.ai-context.yml-sammlung/heimlern.ai-context.yml
@@ -9,7 +9,7 @@ project:
 
 dependencies:
   internal:
-    - name: leitstand
+    - name: chronik
       relationship: uses
       interface:
         - event_feed
@@ -29,7 +29,7 @@ architecture:
     - path: src/scoring/
       purpose: quality scoring & policy checks
   data_flow:
-    input: events/metrics from leitstand
+    input: events/metrics from chronik
     processing: scoring + feedback
     output: reports, signals
 

--- a/heimgewebe-.ai-context.yml-sammlung/mitschreiber.ai-context.yml
+++ b/heimgewebe-.ai-context.yml-sammlung/mitschreiber.ai-context.yml
@@ -13,7 +13,7 @@ dependencies:
       relationship: uses
       interface:
         - jsonl_line_schema
-    - name: leitstand
+    - name: chronik
       relationship: uses
       interface:
         - http_ingest_optional

--- a/heimgewebe-.ai-context.yml-sammlung/vault-gewebe.ai-context.yml
+++ b/heimgewebe-.ai-context.yml-sammlung/vault-gewebe.ai-context.yml
@@ -14,7 +14,7 @@ dependencies:
       interface:
         - semantic_linking
         - search_integration
-    - name: leitstand
+    - name: chronik
       relationship: uses
       interface:
         - ingest_events

--- a/heimgewebe-.ai-context.yml-sammlung/wgx.ai-context.yml
+++ b/heimgewebe-.ai-context.yml-sammlung/wgx.ai-context.yml
@@ -13,7 +13,7 @@ dependencies:
       relationship: uses
       interface:
         - validation_hooks
-    - name: leitstand
+    - name: chronik
       relationship: uses
       interface:
         - ci_e2e_orchestration


### PR DESCRIPTION
This commit renames all references to the `leitstand` backend service to `chronik` within this repository's documentation and `.ai-context.yml` files.

This is part of a larger, ecosystem-wide refactoring to clarify the roles of different services:
- `chronik`: The backend event-ingest and persistence store (formerly `leitstand`).
- `leitstand`: The name for a new, future UI/Dashboard.

This change aligns the documentation and service definitions in this repository with the new naming convention.