### PR TITLE
Fix core lint warnings

### DIFF
--- a/crates/core/src/ask.rs
+++ b/crates/core/src/ask.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 
 use utoipa::{IntoParams, ToSchema};
 
-#[allow(unused_imports)]
 use serde_json::json;
 use crate::AppState;
 

--- a/crates/core/src/chat.rs
+++ b/crates/core/src/chat.rs
@@ -7,7 +7,6 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Serialize};
-#[allow(unused_imports)]
 use serde_json::json;
 use tracing::{debug, warn};
 use utoipa::ToSchema;

--- a/crates/core/src/memory_api.rs
+++ b/crates/core/src/memory_api.rs
@@ -6,6 +6,7 @@ use axum::{
 };
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::fs;
 use std::path::Path;
 use utoipa::ToSchema;


### PR DESCRIPTION
## Summary
- remove unused-import allowances in ask/chat handlers while keeping the `json!` macro available for schema examples
- add the missing `serde_json::json` import to memory API schema definitions
- tidy core library imports and drop the unused dead-code allowance on the app state internals

## Testing
- cargo fmt
- cargo check -p core *(fails: unable to download dependencies in the current environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69253508daa4832cb9b080209d6683b8)