### PR TITLE
fix(ci): add shfmt installation to playbook-gate workflow

### DIFF
--- a/.github/workflows/playbook-gate.yml
+++ b/.github/workflows/playbook-gate.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install shfmt
+        run: sudo apt-get update && sudo apt-get install -y shfmt
+
       - name: Set up Rust toolchain (stable)
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
The playbook-gate workflow was failing because the `shfmt` tool was not found in the runner environment.

This change adds an explicit installation step for `shfmt` using `apt-get` to ensure the dependency is available before any formatting checks are run.