### PR TITLE
fix(ci): correct invalid wgx command in playbook

### DIFF
--- a/playbooks/ai_assist.yml
+++ b/playbooks/ai_assist.yml
@@ -5,7 +5,7 @@ steps:
  - id: gate_lint
    run: |
      if [[ -x ./scripts/wgx ]]; then
-       ./scripts/wgx code lint --fix || exit 1
+       ./scripts/wgx lint --fix || exit 1
      else
        echo "wgx fehlt – überspringe lint";
      fi


### PR DESCRIPTION
The playbook `playbooks/ai_assist.yml` was using an incorrect `wgx code lint` command, which caused CI failures.

This commit corrects the command to the valid `wgx lint`, resolving the issue. The script's original structure, including the check for the local `wgx` executable, has been preserved to maintain expected behavior.