### PR TITLE
docs(copilot): document crates/memory in project structure

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,6 +64,7 @@ Das Repository ist als Cargo-Workspace organisiert:
 - `crates/core` – axum-Server, Policies, Auth, zentrale Services
 - `crates/embeddings` – Vektor-Embeddings aus Textdaten
 - `crates/indexd` – SQLite + tantivy für Indizierung/Suche
+- `crates/memory` – Persistenter Key-Value-Store (SQLite)
 - `crates/policy` – Policy-Datenstrukturen und Logik
 - `crates/policy_api` – API für Policy-Engine
 - `configs/` – Konfigurationsdateien (models.yml, flags.yaml)


### PR DESCRIPTION
The `crates/memory` workspace member exists in `Cargo.toml` but was not documented in the project structure overview for Copilot.

This commit adds the missing entry to `.github/copilot-instructions.md` to maintain accuracy and completeness of the documentation.