### PR TITLE
Align playbook gate toolchain handling

### DIFF
--- a/.github/workflows/playbook-gate.yml
+++ b/.github/workflows/playbook-gate.yml
@@ -2,17 +2,24 @@ name: playbook-gate
 
 on:
   pull_request:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      toolchain:
+        description: "Rust toolchain version to use"
+        default: stable
+        required: false
 
 permissions:
   contents: read
 
+env:
+  CARGO_TERM_COLOR: always
+  toolchain: ${{ inputs.toolchain || github.event.inputs.toolchain || vars.RUST_TOOLCHAIN || 'stable' }}
+  RUST_TOOLCHAIN: ${{ inputs.toolchain || github.event.inputs.toolchain || vars.RUST_TOOLCHAIN || 'stable' }}
+
 jobs:
   gate:
     runs-on: ubuntu-latest
-
-    env:
-      CARGO_TERM_COLOR: always
 
     steps:
       - name: Checkout repository
@@ -21,10 +28,13 @@ jobs:
       - name: Install shfmt
         run: sudo apt-get update && sudo apt-get install -y shfmt
 
-      - name: Set up Rust toolchain (stable)
+      - name: Show resolved toolchain
+        run: echo "Using toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}"
+
+      - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
+          toolchain: ${{ env.RUST_TOOLCHAIN || 'stable' }}
 
       - name: Cache cargo registry + target
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary
- add configurable toolchain inputs and environment fallbacks to playbook-gate workflow
- echo resolved Rust toolchain and use it when installing

## Testing
- not run (workflow configuration change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926952bb258832ca68e94b1cbc2e6fc)