### PR TITLE
Fix CI unshallow fetch handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,9 @@ jobs:
           set -euo pipefail
 
           base_branch="${BASE_REF:-main}"
-          git fetch --no-tags --no-recurse-submodules --unshallow origin "$base_branch"
+          if git rev-parse --is-shallow-repository | grep -q true; then
+            git fetch --no-tags --no-recurse-submodules --unshallow origin "$base_branch"
+          fi
           base_ref="origin/${base_branch}"
           echo "Using base ref: ${base_ref}" >&2
 


### PR DESCRIPTION
## Summary
- guard the unshallow fetch in the changes job to avoid errors when the checkout is already full

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69280f1def64832caa4f5ffb23c31934)