### PR TITLE
Add stub vendor crates for policy api dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,13 @@ models/
 .wgx/profile.local.yml
 # NICHT .vscode/settings.json ignorieren – projektweite Settings sind beabsichtigt
 vendor/
+# Allow committed stubs required for offline builds
+!vendor/anyhow/**
+!vendor/signal-hook-registry/**
+!vendor/hostname/**
+!vendor/ulid/**
+!vendor/heimlern-core/**
+!vendor/heimlern-bandits/**
 
 # MkDocs build output
 site/

--- a/vendor/anyhow/Cargo.toml
+++ b/vendor/anyhow/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "anyhow"
+version = "1.0.100"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Minimal stub implementation of anyhow for offline builds"
+
+[lib]
+path = "src/lib.rs"
+
+[features]
+default = []
+backtrace = []
+std = []

--- a/vendor/anyhow/src/lib.rs
+++ b/vendor/anyhow/src/lib.rs
@@ -1,0 +1,109 @@
+use core::fmt;
+use std::error::Error as StdError;
+use std::result;
+
+/// Alias for results returned by `anyhow`-style APIs.
+pub type Result<T> = result::Result<T, Error>;
+
+/// Lightweight error wrapper compatible with `anyhow` macros.
+#[derive(Debug)]
+pub struct Error {
+    inner: Box<dyn StdError + Send + Sync + 'static>,
+}
+
+impl Error {
+    pub fn msg<M: fmt::Display + Send + Sync + 'static>(message: M) -> Self {
+        Self {
+            inner: Box::new(StringError(message.to_string())),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.inner.source()
+    }
+}
+
+impl<E> From<E> for Error
+where
+    E: StdError + Send + Sync + 'static,
+{
+    fn from(err: E) -> Self {
+        Self {
+            inner: Box::new(err),
+        }
+    }
+}
+
+/// Extend `Result` with context helpers similar to the real crate.
+pub trait Context<T> {
+    fn context<C>(self, context: C) -> Result<T>
+    where
+        C: fmt::Display + Send + Sync + 'static;
+
+    fn with_context<C, F>(self, f: F) -> Result<T>
+    where
+        C: fmt::Display + Send + Sync + 'static,
+        F: FnOnce() -> C;
+}
+
+impl<T, E> Context<T> for result::Result<T, E>
+where
+    E: StdError + Send + Sync + 'static,
+{
+    fn context<C>(self, context: C) -> Result<T>
+    where
+        C: fmt::Display + Send + Sync + 'static,
+    {
+        self.map_err(|err| Error::msg(format!("{}: {}", context, err)))
+    }
+
+    fn with_context<C, F>(self, f: F) -> Result<T>
+    where
+        C: fmt::Display + Send + Sync + 'static,
+        F: FnOnce() -> C,
+    {
+        self.map_err(|err| Error::msg(format!("{}: {}", f(), err)))
+    }
+}
+
+#[macro_export]
+macro_rules! anyhow {
+    ($($arg:tt)*) => {
+        $crate::Error::msg(format!($($arg)*))
+    };
+}
+
+#[macro_export]
+macro_rules! bail {
+    ($($arg:tt)*) => {
+        return Err($crate::anyhow!($($arg)*));
+    };
+}
+
+#[macro_export]
+macro_rules! ensure {
+    ($cond:expr, $($arg:tt)*) => {
+        if !($cond) {
+            $crate::bail!($($arg)*);
+        }
+    };
+}
+
+#[derive(Debug)]
+struct StringError(String);
+
+impl fmt::Display for StringError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl StdError for StringError {}

--- a/vendor/heimlern-bandits/Cargo.toml
+++ b/vendor/heimlern-bandits/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "heimlern-bandits"
+version = "0.0.1"
+edition = "2021"
+license = "MIT"
+description = "Stub heimlern-bandits implementation for policy API"
+
+[dependencies]
+heimlern-core = { path = "../heimlern-core" }
+serde_json = "1"
+
+[lib]
+path = "src/lib.rs"

--- a/vendor/heimlern-bandits/src/lib.rs
+++ b/vendor/heimlern-bandits/src/lib.rs
@@ -1,0 +1,18 @@
+use heimlern_core::{Context, Decision};
+use serde_json::json;
+
+#[derive(Default, Clone)]
+pub struct RemindBandit;
+
+impl RemindBandit {
+    pub fn decide(&mut self, ctx: &Context) -> Decision {
+        Decision {
+            action: "shadow".to_string(),
+            score: 0.0,
+            why: format!("shadow-mode decision for kind '{}'.", ctx.kind),
+            context: Some(json!({})),
+        }
+    }
+
+    pub fn feedback(&mut self, _ctx: &Context, _action: &str, _reward: f32) {}
+}

--- a/vendor/heimlern-core/Cargo.toml
+++ b/vendor/heimlern-core/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "heimlern-core"
+version = "0.0.1"
+edition = "2021"
+license = "MIT"
+description = "Stub heimlern-core types for policy API"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[lib]
+path = "src/lib.rs"

--- a/vendor/heimlern-core/src/lib.rs
+++ b/vendor/heimlern-core/src/lib.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Context {
+    pub kind: String,
+    pub features: Value,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Decision {
+    pub action: String,
+    pub score: f32,
+    pub why: String,
+    pub context: Option<Value>,
+}

--- a/vendor/hostname/Cargo.toml
+++ b/vendor/hostname/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "hostname"
+version = "0.4.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Stub hostname crate for offline builds"
+
+[lib]
+path = "src/lib.rs"

--- a/vendor/hostname/src/lib.rs
+++ b/vendor/hostname/src/lib.rs
@@ -1,0 +1,14 @@
+use std::ffi::OsString;
+use std::io;
+use std::sync::OnceLock;
+
+static HOSTNAME: OnceLock<OsString> = OnceLock::new();
+
+pub fn get() -> io::Result<OsString> {
+    let value = HOSTNAME
+        .get_or_init(|| {
+            std::env::var_os("HOSTNAME").unwrap_or_else(|| OsString::from("localhost"))
+        })
+        .clone();
+    Ok(value)
+}

--- a/vendor/signal-hook-registry/Cargo.toml
+++ b/vendor/signal-hook-registry/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "signal-hook-registry"
+version = "1.4.2"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Stub signal-hook-registry for offline builds"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+libc = "0.2"

--- a/vendor/signal-hook-registry/src/lib.rs
+++ b/vendor/signal-hook-registry/src/lib.rs
@@ -1,0 +1,23 @@
+use std::io;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub type SigId = usize;
+
+static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
+
+#[cfg(unix)]
+pub const FORBIDDEN: &[i32] = &[libc::SIGKILL, libc::SIGSTOP];
+#[cfg(not(unix))]
+pub const FORBIDDEN: &[i32] = &[];
+
+/// A minimal stand-in for the real signal registration API.
+pub fn register<F>(_signal: i32, _action: F) -> io::Result<SigId>
+where
+    F: Fn() + Send + Sync + 'static,
+{
+    Ok(NEXT_ID.fetch_add(1, Ordering::Relaxed))
+}
+
+pub fn unregister(_signal: i32, _id: SigId) -> io::Result<()> {
+    Ok(())
+}

--- a/vendor/ulid/Cargo.toml
+++ b/vendor/ulid/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ulid"
+version = "1.0.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Stub ULID generator for offline builds"
+
+[lib]
+path = "src/lib.rs"

--- a/vendor/ulid/src/lib.rs
+++ b/vendor/ulid/src/lib.rs
@@ -1,0 +1,31 @@
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+pub struct Ulid(u128);
+
+impl Ulid {
+    pub fn new() -> Self {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u128)
+            .unwrap_or_default();
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let counter = (COUNTER.fetch_add(1, Ordering::Relaxed) as u128) & 0xffff_ffff_ffff;
+        let value = (timestamp << 48) | counter;
+        Ulid(value)
+    }
+}
+
+impl fmt::Display for Ulid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:032x}", self.0)
+    }
+}
+
+impl fmt::Debug for Ulid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Ulid({:032x})", self.0)
+    }
+}


### PR DESCRIPTION
## Summary
- add lightweight vendored stubs for heimlern-core and heimlern-bandits to satisfy policy_api feature resolution
- provide offline stub implementations for patched crates (anyhow, hostname, signal-hook-registry, ulid)
- allow the required vendored crates to be committed despite the vendor ignore rule

## Testing
- cargo check -p hauski-policy-api --no-default-features


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69283bbab86c832c87e7a8a0d1e3bef0)