### PR TITLE
fix(deny): update graph section in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,8 +1,6 @@
 [graph]
-targets = [
-    { triple = "x86_64-unknown-linux-gnu" },
-    { triple = "aarch64-unknown-linux-gnu" },
-]
+output = "graph.svg"
+targets = ["all"]
 
 [advisories]
 version = 2


### PR DESCRIPTION
- Replace explicit `targets` structs with simplified `["all"]` list.
- Add missing `output` field to `[graph]` section.
- This resolves a `table with missing field` deserialization error in CI.