### PR TITLE
Clarify deny license exceptions placement

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -50,7 +50,8 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = []
 
-# Lizenz-Mapping/Exceptions für verbreitete Kombis (nur falls nötig):
+# Lizenz-Mapping/Exceptions für verbreitete Kombis (nur falls nötig). Dieser Block muss am
+# Ende der Datei stehen; keine weiteren Konfigurationen danach platzieren.
 [[licenses.exceptions]]
 name = "ring"
 allowed = ["MIT", "ISC", "OpenSSL"]


### PR DESCRIPTION
## Summary
- note that the licenses exceptions block must remain at the end of the deny configuration to satisfy parser expectations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ada0709ec832c98ef0091a7a8bd8c)