### PR TITLE
ci: remove HEIMGEWEBE_AUTOBOT_TOKEN from pr-heimgewebe-commands workflow

### DIFF
--- a/.github/workflows/pr-heimgewebe-commands.yml
+++ b/.github/workflows/pr-heimgewebe-commands.yml
@@ -13,5 +13,3 @@ jobs:
   dispatch:
     if: github.event.issue.pull_request != null
     uses: heimgewebe/metarepo/.github/workflows/heimgewebe-command-dispatch.yml@main
-    secrets:
-      HEIMGEWEBE_AUTOBOT_TOKEN: ${{ secrets.HEIMGEWEBE_AUTOBOT_TOKEN }}


### PR DESCRIPTION
The reusable workflow now handles the App Token retrieval internally, so passing the PAT explicitly is no longer needed. This removes the PAT dependency.