### PR TITLE
fix(ci): improve toolchain variable derivation in playbook-gate

### DIFF
--- a/.github/workflows/playbook-gate.yml
+++ b/.github/workflows/playbook-gate.yml
@@ -16,11 +16,10 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   # Provide toolchain variable from input or fallback to stable.
-  # `inputs.toolchain` would be set if this workflow is invoked via workflow_call (not currently supported),
-  # `github.event.inputs.toolchain` is set for workflow_dispatch.
-  # The fallback chain matches ci.yml for consistency.
-  toolchain: ${{ inputs.toolchain || github.event.inputs.toolchain || vars.RUST_TOOLCHAIN || 'stable' }}
-  RUST_TOOLCHAIN: ${{ inputs.toolchain || github.event.inputs.toolchain || vars.RUST_TOOLCHAIN || 'stable' }}
+  # Using vars.RUST_TOOLCHAIN allows overriding the toolchain via repository variables,
+  # otherwise defaulting to stable. This avoids issues with undefined inputs in PR triggers.
+  toolchain: ${{ vars.RUST_TOOLCHAIN || 'stable' }}
+  RUST_TOOLCHAIN: ${{ vars.RUST_TOOLCHAIN || 'stable' }}
 
 jobs:
   gate:


### PR DESCRIPTION
This commit updates the `toolchain` and `RUST_TOOLCHAIN` environment variable derivation in `.github/workflows/playbook-gate.yml` to rely on `vars.RUST_TOOLCHAIN` or a default of `'stable'`.

This change addresses a failure in Pull Request triggers where `inputs` and `github.event.inputs` are undefined or empty, causing the previous expression to fail or resolve incorrectly. The new approach is robust for PRs while still allowing organization-level overrides via repository variables.

Ref: 49e636a25085ff569b5663fd9a330b0f3de7edd4