### PR TITLE
Fix toolchain default resolution in playbook gate

### DIFF
--- a/.github/workflows/playbook-gate.yml
+++ b/.github/workflows/playbook-gate.yml
@@ -19,8 +19,8 @@ env:
   # Using vars.RUST_TOOLCHAIN allows overriding the toolchain via repository variables,
   # otherwise defaulting to stable. This avoids issues with undefined inputs in PR triggers.
   # The explicit != '' check ensures proper evaluation even when the variable is empty.
-  toolchain: ${{ inputs.toolchain || github.event.inputs.toolchain || (vars.RUST_TOOLCHAIN != '' && vars.RUST_TOOLCHAIN) || 'stable' }}
-  RUST_TOOLCHAIN: ${{ inputs.toolchain || github.event.inputs.toolchain || (vars.RUST_TOOLCHAIN != '' && vars.RUST_TOOLCHAIN) || 'stable' }}
+  toolchain: ${{ (github.event_name == 'workflow_dispatch' && inputs.toolchain) || (github.event_name == 'workflow_dispatch' && github.event.inputs.toolchain) || (vars.RUST_TOOLCHAIN != '' && vars.RUST_TOOLCHAIN) || 'stable' }}
+  RUST_TOOLCHAIN: ${{ (github.event_name == 'workflow_dispatch' && inputs.toolchain) || (github.event_name == 'workflow_dispatch' && github.event.inputs.toolchain) || (vars.RUST_TOOLCHAIN != '' && vars.RUST_TOOLCHAIN) || 'stable' }}
 
 jobs:
   gate:


### PR DESCRIPTION
## Summary
- ensure the playbook gate workflow resolves a Rust toolchain value even when workflow inputs are unavailable
- keep workflow-dispatch inputs supported while defaulting to repository variable or stable

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d7ac7564c832c813475ed8517c408)