### PR TITLE
fix(scripts): handle null values in hauski-run and fix vendor checks

### DIFF
--- a/scripts/check-vendor.sh
+++ b/scripts/check-vendor.sh
@@ -7,9 +7,9 @@ set -euo pipefail
 # "no matching package" error because the workspace is configured to replace the
 # crates.io registry with the local vendor tree.
 REQUIRED_CRATES=(
-  "axum"
-  "tokio"
-  "serde"
+  "heimlern-core"
+  "anyhow"
+  "hostname"
 )
 
 missing=()

--- a/scripts/hauski-run.sh
+++ b/scripts/hauski-run.sh
@@ -26,9 +26,11 @@ MODEL="${HAUSKI_CHAT_MODEL:-}"
 # aus flags.yaml ziehen, wenn ENV leer
 if [[ -z "${URL}" && -f "${FLAGS_FILE}" ]]; then
   URL="$(awk -F': *' '/^chat_upstream_url:/ {print $2}' "${FLAGS_FILE}" | tr -d '"' || true)"
+  if [[ "${URL}" == "null" ]]; then URL=""; fi
 fi
 if [[ -z "${MODEL}" && -f "${FLAGS_FILE}" ]]; then
   MODEL="$(awk -F': *' '/^chat_model:/ {print $2}' "${FLAGS_FILE}" | tr -d '"' || true)"
+  if [[ "${MODEL}" == "null" ]]; then MODEL=""; fi
 fi
 
 # konservativer Default für URL; Modell lieber explizit


### PR DESCRIPTION
- Modified `scripts/hauski-run.sh` to correctly handle `null` values extracted from `configs/flags.yaml`. Previously, `awk` extracted the string literal "null", which was treated as a valid value, preventing fallback defaults and causing runtime errors. Now, "null" is explicitly converted to an empty string.
- Updated `scripts/check-vendor.sh` to check for `heimlern-core`, `anyhow`, and `hostname` instead of `axum`, `tokio`, and `serde`. This reflects the actual vendoring configuration and eliminates false warnings.