### PR TITLE
feat(core): implement 501 placeholders for plugin and cloud routes

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1351,10 +1351,17 @@ mod tests {
             .unwrap();
         assert_eq!(res.status(), StatusCode::NOT_IMPLEMENTED);
         let body = res.into_body().collect().await.unwrap().to_bytes();
-        assert_eq!(body, "Plugins are not yet implemented (see docs/inconsistencies.md)");
+        assert_eq!(
+            body,
+            "Plugins are not yet implemented (see docs/inconsistencies.md)"
+        );
 
         let res = app
-            .oneshot(Request::get("/plugins/foo/bar").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::get("/plugins/foo/bar")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::NOT_IMPLEMENTED);


### PR DESCRIPTION
- Implements `plugin_routes` and `cloud_routes` with `501 Not Implemented`.
- Updates the routing logic to use `{*path}` syntax for catch-all routes, as required by the current axum/matchit version.
- Adds tests to verify the 501 status and error message for these routes.
- Resolves inconsistencies documented in `docs/inconsistencies.md` regarding unimplemented routes.