### PR TITLE
docs: fix broken links and structure for mkdocs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Beitrag zu HausKI
+
+**Rahmen:** HausKI ist ein Rust-zentriertes KI-Orchestrator-Projekt mit Fokus auf Offline-Betrieb auf NVIDIA-RTX-Hardware. Ziel ist ein wartbares Monorepo mit klaren Schnittstellen (CLI, Core, Policies, Modelle). Änderungen sollen klein, überprüfbar und reproduzierbar bleiben.
+
+## Grundregeln
+
+- **Sprache:** Dokumentation, Commit-Nachrichten und Hilfetexte auf Deutsch verfassen. Code-Kommentare und Logs bleiben Englisch.
+- **Portabilität:** Pop!_OS ist der Referenz-Stack, doch Termux/WSL/Codespaces dürfen nicht brechen. Keine Linux-Distro-spezifischen Flags ohne Absicherung.
+- **Sicherheit:** Shell-Skripte laufen mit `set -euo pipefail`. Keine stillen Fehler oder unkontrollierte Netzwerkzugriffe.
+- **Hilfen:** CLI-Kommandos müssen `-h|--help` anbieten und beschreiben Defaults, Flags sowie Konfigurationspfade.
+
+## Entwicklungsumgebung
+
+- Nutze den Devcontainer (`.devcontainer/`). Er bringt `rustup`, CUDA-Basis, `cargo-deny`, `just` und Vale mit.
+- Lokale Entwicklung außerhalb des Containers erfordert die manuelle Installation von Rust, CUDA-Treibern, Vale und `cargo-deny`.
+- Halte `.wgx/profile.yml` und etwaige lokale Overrides aktuell (`.wgx/profile.local.yml`).
+
+## Lint & Tests
+
+- Formatierung: `cargo fmt --all`.
+- Lints: `cargo clippy --all-targets --all-features -- -D warnings` und `cargo deny check`.
+- Tests: `cargo test --workspace -- --nocapture`.
+- Optional: Vale für Prosa (`vale .`) und `wgx validate --profile .wgx/profile.yml` für Task-Definitionen.
+
+## Commits & PRs
+
+- Conventional-Commit-Präfixe verwenden (`feat: …`, `fix: …`, `docs: …`, `refactor: …`, `chore(core): …`).
+- Commits klein halten, Änderungen logisch gruppieren und auf Deutsch beschreiben.
+- PR-Beschreibung: Fokus, Motivation und „Wie getestet“ angeben. Hinweise auf GPU-spezifische Pfade oder Policies nicht vergessen.
+
+## Definition of Done
+
+- CI grün: `cargo fmt`, `cargo clippy`, `cargo test`, `cargo deny`, Vale (für Docs) und optionale WGX-Smoke-Checks.
+- Für neue oder geänderte CLI-Kommandos: Hilfetext, Tests (bats oder Rust) und aktualisierte Dokumentation.
+- Policies und Modelle müssen dokumentiert sowie in `configs/` bzw. `policies/` gepflegt werden.
+- GPU-relevante Änderungen dokumentieren (Thermik, Speicher, Limits) und ggf. in der Roadmap ergänzen.
+
+## Development Workflow
+
+Um zur `hauski` beizutragen, folgen Sie bitte diesen Schritten:
+
+1. **Forken Sie das Repository**: Erstellen Sie einen Fork des Haupt-Repositorys in Ihrem eigenen GitHub-Account.
+2. **Klonen Sie den Fork**: Klonen Sie Ihren Fork auf Ihre lokale Maschine.
+3. **Erstellen Sie einen Branch**: Erstellen Sie einen neuen Branch für Ihre Änderungen.
+4. **Nehmen Sie Änderungen vor**: Implementieren Sie Ihre Änderungen und stellen Sie sicher, dass sie den Coding Style Guide einhalten.
+5. **Führen Sie Tests durch**: Führen Sie die Tests aus, um sicherzustellen, dass Ihre Änderungen keine bestehenden Funktionalitäten beeinträchtigen.
+6. **Committen Sie Ihre Änderungen**: Committen Sie Ihre Änderungen mit einer aussagekräftigen Commit-Nachricht.
+7. **Pushen Sie Ihre Änderungen**: Pushen Sie Ihre Änderungen in Ihren Fork.
+8. **Erstellen Sie einen Pull Request**: Erstellen Sie einen Pull Request vom Ihrem Branch in den `main`-Branch des Haupt-Repositorys.
+
+## Coding Style Guide
+
+- **Formatierung**: Der Code sollte mit `cargo fmt` formatiert werden.
+- **Benennung**: Variablen und Funktionsnamen sollten `snake_case` sein. Typnamen sollten `PascalCase` sein.
+- **Dokumentation**: Alle öffentlichen Funktionen und Typen sollten dokumentiert werden.
+- **Fehlerbehandlung**: Verwenden Sie `thiserror` und `anyhow` zur Fehlerbehandlung.

--- a/docs/hauski-skizze.md
+++ b/docs/hauski-skizze.md
@@ -2,7 +2,7 @@
 
 > **⚠️ Hinweis:** Dieses Dokument beschreibt die **Architektur-Vision** von HausKI.
 > Nicht alle hier beschriebenen Features sind bereits implementiert.
-> Für den **aktuellen Implementierungsstatus** siehe [`docs/ist-stand-vs-roadmap.md`](docs/ist-stand-vs-roadmap.md).
+> Für den **aktuellen Implementierungsstatus** siehe [`ist-stand-vs-roadmap.md`](ist-stand-vs-roadmap.md).
 
 ## 0) Kurzfassung
 

--- a/docs/hauski-stack.md
+++ b/docs/hauski-stack.md
@@ -3,7 +3,7 @@
 
 > **⚠️ Hinweis:** Dieses Dokument beschreibt die **angestrebte Technologie-Stack-Vision**.
 > Nicht alle hier aufgeführten Komponenten sind bereits implementiert.
-> Für den **aktuellen Implementierungsstatus** siehe [`docs/ist-stand-vs-roadmap.md`](docs/ist-stand-vs-roadmap.md).
+> Für den **aktuellen Implementierungsstatus** siehe [`ist-stand-vs-roadmap.md`](ist-stand-vs-roadmap.md).
 
 ## 0) Übersicht
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,18 +14,18 @@ just py-fmt        # Ruff-Formatter ausführen
 Weitere Einstiegspunkte:
 
 - [README](https://github.com/heimgewebe/hausKI/blob/main/README.md) – Gesamtüberblick, Setup und Devcontainer-Workflows
-- [hauski-stack.md](https://github.com/heimgewebe/hausKI/blob/main/hauski-stack.md) – Tech-Stack, Architekturrollen und Roadmap
-- [hauski-skizze.md](https://github.com/heimgewebe/hausKI/blob/main/hauski-skizze.md) – visuelle Skizze der Systemkomponenten
+- [hauski-stack.md](./hauski-stack.md) – Tech-Stack, Architekturrollen und Roadmap
+- [hauski-skizze.md](./hauski-skizze.md) – visuelle Skizze der Systemkomponenten
 
 ## Inhaltsverzeichnis
 
 | Bereich | Beschreibung |
 | --- | --- |
-| [Architektur](https://github.com/heimgewebe/hausKI/blob/main/hauski-stack.md) | Stack-Entscheidungen, Modulzuschnitt und Budgets |
+| [Architektur](./hauski-stack.md) | Stack-Entscheidungen, Modulzuschnitt und Budgets |
 | [Module](modules/index.md) | Fokusseiten zu Kern-Crates wie `core`, `memory` und `audio` |
 | [Runbooks](runbooks/index.md) | Schritt-für-Schritt-Anleitungen für Setup und Betrieb |
 | [semantAH](semantah.md) | Deep Dive in Embeddings, KPIs und Deploy |
-| [Prozesse](process/) | Sprachleitfaden, Tests, Release-Checks |
+| [Prozesse](process/README.md) | Sprachleitfaden, Tests, Release-Checks |
 
 ## Aktuelle Schwerpunkte
 

--- a/docs/ist-stand-vs-roadmap.md
+++ b/docs/ist-stand-vs-roadmap.md
@@ -284,6 +284,6 @@ Die folgenden Crates existieren **nicht** unter `crates/`:
 ## Referenzen
 
 - [`docs/inconsistencies.md`](./inconsistencies.md) – Detaillierte Analyse der Abweichungen
-- [`hauski-skizze.md`](../hauski-skizze.md) – Architektur-Vision (Roadmap-fokussiert)
-- [`hauski-stack.md`](../hauski-stack.md) – Technologie-Stack (Mix aus Ist/Roadmap)
-- [`CONTRIBUTING.md`](../CONTRIBUTING.md) – Beitragsrichtlinien und DoD
+- [`hauski-skizze.md`](./hauski-skizze.md) – Architektur-Vision (Roadmap-fokussiert)
+- [`hauski-stack.md`](./hauski-stack.md) – Technologie-Stack (Mix aus Ist/Roadmap)
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) – Beitragsrichtlinien und DoD

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,14 @@ theme:
     - search.highlight
 nav:
   - Start: index.md
+  - Architektur:
+      - Vision: hauski-skizze.md
+      - Stack: hauski-stack.md
+      - Status: ist-stand-vs-roadmap.md
+      - Inkonsistenzen: inconsistencies.md
+      - Ambient Assistant: ambient-assistant.md
+      - Heimgeist Integration: integration_with_heimgeist.md
+      - Vision (RAG): vision/multi-agent-rag.md
   - API: api.md
   - CLI: cli.md
   - Module:
@@ -33,8 +41,10 @@ nav:
       - Sprache: process/sprache.md
       - Tests & Qualität: process/testing.md
       - Release: process/release.md
-  - Vision: vision/multi-agent-rag.md
+      - Review-Cycle: review-cycle.md
   - ADRs:
+      - Übersicht: adr/README.md
+      - Ziele & Scope: adr/ADR-0001__ziele-und-scope.md
       - Toolchain-Strategie: adrs/ADR-0001-toolchain-strategy.md
   - Runbooks:
       - Übersicht: runbooks/index.md
@@ -47,6 +57,9 @@ nav:
       - Upgrade-Guide: runbooks/upgrade-guide.md
   - semantAH: semantah.md
   - Audit: audit-hauski.md
+  - Contributing: CONTRIBUTING.md
+  - Canvas:
+      - Codex: canvas/codex/README.md
 markdown_extensions:
   - admonition
   - toc:


### PR DESCRIPTION
- Move `hauski-skizze.md` and `hauski-stack.md` to `docs/` to satisfy mkdocs linking requirements.
- Copy `CONTRIBUTING.md` to `docs/CONTRIBUTING.md`.
- Update relative links in `ist-stand-vs-roadmap.md`, `index.md`, `hauski-skizze.md`, and `hauski-stack.md`.
- Update `mkdocs.yml` navigation to include missing pages and reflect the new file structure.
- Ensure `uv run mkdocs build --strict --clean` passes.
- Verified linting (`just lint`) and tests (`just test`) are passing.