### PR TITLE
docs(contracts): add x-repo event mapping

### DIFF
--- a/docs/contracts/x-repo-events.md
+++ b/docs/contracts/x-repo-events.md
@@ -4,14 +4,17 @@ Dieses Dokument verankert die hausKI-Eventwelt explizit in den zentralen Heimgew
 
 ## 1. Zentrale Contracts (metarepo)
 
-Die kanonischen Event- und Insight-Contracts liegen im Contracts-Repo (metarepo):
+Die kanonischen Event- und Insight-Contracts liegen im **metarepo**  
+im Verzeichnis `contracts/` (JSON Schema Draft 2020-12):
 
 - `contracts/aussen.event.schema.json` – externe Roh-Events (Feeds, News, etc.)
 - `contracts/event.line.schema.json` – normalisierte Event-Linien im Chronik-Backbone
+- `contracts/insights.schema.json` – generische semantische Insights
 - `contracts/insights.daily.schema.json` – tägliche semantische Zusammenfassungen (semantAH → leitstand → hausKI)
 - `contracts/fleet.health.schema.json` – Fleet-Gesundheitszustand (wgx / Leitstand)
 
-hausKI definiert **keine alternativen Versionen** dieser Schemas, sondern arbeitet auf Basis dieser Kanon-Contracts.
+hausKI definiert **keine alternativen Versionen** dieser Schemas,  
+sondern arbeitet vollständig auf Basis dieser kanonischen Contracts.
 
 ## 2. hausKI-Events im Kontext von `event.line`
 
@@ -73,6 +76,7 @@ Für externe Events sollte dieses Dokument regelmäßig angepasst werden, sobald
 
 Langfristig ist geplant:
 
+- stärkere Nutzung von `$ref` auf zentrale Contracts im metarepo,
 - die hausKI-Event-Schemas teilweise direkt auf die zentralen Contracts zu referenzieren (z. B. via `$ref`),
 - zusätzliche hausKI-Contracts (z. B. für Policy-Snapshots) im zentralen Contracts-Repo zu spiegeln.
 
@@ -80,3 +84,45 @@ Bis dahin dient dieses Dokument als lebende Brücke zwischen:
 
 - dem zentralen Contract-Backbone im metarepo und
 - den internen Entscheidungs-Events in hausKI.
+
+---
+
+## 6. Pflege / Maintenance
+
+Dieses Dokument **muss aktualisiert werden**, wenn:
+
+1. **Neue zentrale Contracts** im metarepo unter `contracts/*.schema.json` angelegt,
+   umbenannt oder entfernt werden.
+
+2. **Neue hausKI-Eventtypen** entstehen, die:
+   - externe Contracts konsumieren (z. B. neue Varianten von `event.line`),
+   - oder selbst wieder Anschluss an Chronik/Leitstand haben.
+
+3. **semantAH** neue Insight- oder Graph-Contracts einführt, die hausKI konsumiert.
+
+4. **Policy- oder Fleet-spezifische Contracts** (z. B. `policy.snapshot`, `fleet.health`)
+   in hausKI-Events referenziert werden.
+
+Ziel:
+
+- hausKI folgt dem zentralen Contract-Backbone,
+- dieses Dokument beschreibt die verbindliche x-repo-Integration.
+
+---
+
+## 7. Beispiel: Nutzung von `$ref` zur Verankerung in zentralen Contracts
+
+hausKI kann Felder (z. B. `event_id`, `origin`, `context`) direkt an die zentralen
+Definitionsquellen anbinden. Beispiel:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "event_id": { "$ref": "https://schemas.heimgewebe.de/event/event.line.schema.json#/properties/id" },
+    "origin":   { "$ref": "https://schemas.heimgewebe.de/event/aussen.event.schema.json#/properties/source" }
+  }
+}
+```
+
+So bleibt hausKI strukturell kompatibel mit dem Backbone und profitiert automatisch von dessen Weiterentwicklung.


### PR DESCRIPTION
This adds `docs/contracts/x-repo-events.md` to map hausKI's internal events to the central contracts in the metarepo (e.g., `event.line`, `aussen.event`). It documents the producers and consumers of these events and explains how hausKI events relate to and extend the canonical event stream.