### PR TITLE
Add Heimgewebe organism context block to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,3 +549,14 @@ Für eine dauerhafte Installation kann `hauski` als `systemd`-Dienst konfigurier
   3. commit & push
 
 Ohne aktualisiertes `uv.lock` bricht CI mit einem klaren Hinweis ab.
+
+## Organismus-Kontext
+
+Dieses Repository ist Teil des **Heimgewebe-Organismus**.
+
+Die übergeordnete Architektur, Achsen, Rollen und Contracts sind zentral beschrieben im  
+👉 [`metarepo/docs/heimgewebe-organismus.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-organismus.md)  
+👉 [`metarepo/docs/heimgewebe-zielbild.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/heimgewebe-zielbild.md).
+
+Alle Rollen-Definitionen, Datenflüsse und Contract-Zuordnungen dieses Repos
+sind dort verankert.


### PR DESCRIPTION
## Summary
- add the Heimgewebe Organismus context section to the README with links to the metarepo documentation

## Testing
- not run (documentation only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693558555500832cacc1c3546d187121)