### PR TITLE
Handle empty HAUSKI_DATA fallback

### DIFF
--- a/services/policy_shadow/app.py
+++ b/services/policy_shadow/app.py
@@ -19,7 +19,8 @@ EVENT_BASE_ENV = "HAUSKI_DATA"
 
 
 def _event_dir() -> Path:
-    base = Path(os.getenv(EVENT_BASE_ENV, Path.home() / ".hauski"))
+    base_env = os.getenv(EVENT_BASE_ENV)
+    base = Path(base_env) if base_env else Path.home() / ".hauski"
     events_dir = base / "events"
     events_dir.mkdir(parents=True, exist_ok=True)
     return events_dir


### PR DESCRIPTION
## Summary
- ensure the policy shadow service ignores an empty HAUSKI_DATA override and falls back to the default events directory

## Testing
- python -m compileall services/policy_shadow/app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69391d37b9c4832c9f91a7b45926e8af)