### PR TITLE
feat(core): implement tooling hooks for assist code mode

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -130,6 +130,8 @@ struct AppStateInner {
     /// Only set to `true` if you understand the security implications.
     expose_config: bool,
     ready: AtomicBool,
+    /// Tool registry for assist code mode.
+    tools: Arc<tools::ToolRegistry>,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -213,6 +215,11 @@ impl AppState {
                 reqwest::Client::new()
             });
 
+        // Initialize tool registry with built-in tools
+        let mut tool_registry = tools::ToolRegistry::new();
+        tool_registry.register(Arc::new(tools::EchoTool));
+        tool_registry.register(Arc::new(tools::CodeAnalysisTool));
+
         Self(Arc::new(AppStateInner {
             limits,
             models,
@@ -228,6 +235,7 @@ impl AppState {
             http_client,
             expose_config,
             ready: AtomicBool::new(false),
+            tools: Arc::new(tool_registry),
         }))
     }
 
@@ -295,6 +303,10 @@ impl AppState {
 
     pub fn http_client(&self) -> reqwest::Client {
         self.0.http_client.clone()
+    }
+
+    pub fn tools(&self) -> Arc<tools::ToolRegistry> {
+        self.0.tools.clone()
     }
 }
 

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -26,6 +26,12 @@ pub struct ToolRegistry {
     tools: HashMap<String, Arc<dyn Tool>>,
 }
 
+impl Default for ToolRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ToolRegistry {
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
- Added `crates/core/src/tools.rs` with `Tool` trait and `ToolRegistry`.
- Implemented `CodeAnalysisTool` (stub) and `EchoTool`.
- Integrated tool execution into `assist_handler` in `crates/core/src/assist.rs` for "code" mode.
- Added tests for new tooling infrastructure and integration.