### PR TITLE
Add stable toolchain to reusable workflows

### DIFF
--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -187,4 +187,5 @@ jobs:
     uses: heimgewebe/contracts/.github/workflows/contracts-ajv-reusable.yml@contracts-v1
     secrets: inherit
     with:
+      toolchain: stable
       fixtures_glob: ${{ vars.FIXTURES_GLOB || 'fixtures/**/*.jsonl' }}

--- a/.github/workflows/pr-heimgewebe-commands.yml
+++ b/.github/workflows/pr-heimgewebe-commands.yml
@@ -15,3 +15,5 @@ jobs:
     if: github.event.issue.pull_request != null
     uses: heimgewebe/metarepo/.github/workflows/heimgewebe-command-dispatch.yml@main
     secrets: inherit
+    with:
+      toolchain: stable

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -16,3 +16,5 @@ jobs:
     # Fleet-Repos, die von metarepo aus via wgx up Templates beziehen,
     # werden auf den kanonischen Guard-Workflow aus heimgewebe/wgx gesetzt.
     uses: heimgewebe/wgx/.github/workflows/wgx-guard.yml@main
+    with:
+      toolchain: stable

--- a/.github/workflows/wgx-smoke.yml
+++ b/.github/workflows/wgx-smoke.yml
@@ -14,3 +14,5 @@ jobs:
     # auch hier: statt eigener CI-Logik nur noch Forwarder auf das
     # kanonische wgx-Workflow-Repo.
     uses: heimgewebe/wgx/.github/workflows/wgx-smoke.yml@main
+    with:
+      toolchain: stable


### PR DESCRIPTION
## Summary
- add toolchain input set to stable for reusable guard and smoke workflows
- ensure command dispatch and contracts validation workflows use stable toolchain

## Testing
- not run (workflow configuration change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c1adf64a4832c98e63180d7a07ed0)