### PR TITLE
Expose memory routes when config UI is disabled

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -557,17 +557,16 @@ pub fn build_app_with_state(
         let swagger = SwaggerUi::new("/docs").url("/api-docs/openapi.json", ApiDoc::openapi());
 
         app = app.merge(config_routes()).merge(swagger);
-
-        // Conditionally add memory routes if the subsystem is up.
-        if memory_initialized {
-            app = app.merge(memory_routes());
-        }
     }
 
     if state.safe_mode() {
         tracing::info!("SAFE-MODE active: plugins and cloud routes disabled");
     } else {
         app = app.merge(plugin_routes()).merge(cloud_routes());
+    }
+
+    if memory_initialized {
+        app = app.merge(memory_routes());
     }
 
     let timeout_layer = if timeout_ms > 0 {

--- a/crates/core/tests/memory_routes.rs
+++ b/crates/core/tests/memory_routes.rs
@@ -1,0 +1,65 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::{
+    body::Body,
+    http::{self, HeaderValue, Request, StatusCode},
+};
+use hauski_core::{build_app_with_state, FeatureFlags, Limits, ModelsFile, RoutingPolicy};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn memory_routes_available_without_expose_config() {
+    let limits = Limits::default();
+    let models = ModelsFile::default();
+    let routing = RoutingPolicy::default();
+    let flags = FeatureFlags::default();
+    let allowed_origin = HeaderValue::from_static("*");
+    let (app, _state) = build_app_with_state(limits, models, routing, flags, false, allowed_origin);
+
+    let key = format!(
+        "memory-test-{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos()
+    );
+    let set_payload = json!({ "key": key, "value": "hello" });
+
+    let set_response = app
+        .clone()
+        .oneshot(
+            Request::post("/memory/set")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(set_payload.to_string()))
+                .expect("failed to build request"),
+        )
+        .await
+        .expect("set request failed");
+
+    assert_eq!(set_response.status(), StatusCode::OK);
+
+    let get_payload = json!({ "key": key });
+    let get_response = app
+        .clone()
+        .oneshot(
+            Request::post("/memory/get")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(get_payload.to_string()))
+                .expect("failed to build request"),
+        )
+        .await
+        .expect("get request failed");
+
+    assert_eq!(get_response.status(), StatusCode::OK);
+
+    let body_bytes = get_response
+        .into_body()
+        .collect()
+        .await
+        .expect("body bytes")
+        .to_bytes();
+    let payload: Value = serde_json::from_slice(&body_bytes).expect("response json");
+    assert_eq!(payload["value"], "hello");
+}


### PR DESCRIPTION
## Summary
- expose the memory API routes whenever the subsystem initializes, regardless of the config UI flag
- add an integration test to confirm the memory endpoints are reachable with default settings

## Testing
- cargo test -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d38188e94832c833dc605c9acf65c)