### PR TITLE
doc: document CI workflow semantics and classification

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,10 +1,15 @@
 # CI Workflows
 
-This directory contains the CI/CD definitions for the HausKI project. To prevent drift and redundancy, workflows are semantically classified into three categories.
+> **Note:** This document is a conceptual map, not an exhaustive list. Please refer to the file listing for the canonical set of workflows.
+>
+> **Source of Truth:** The workflow files themselves are the authoritative source. Each key workflow file is marked with a `# CLASS: <type>` header.
+
+To prevent drift and redundancy, workflows are semantically classified into three categories.
 
 ## 1. Baseline (Always)
 **Must always run.** Minimal, fast, unambiguous.
-*   `ci.yml`: The central CI pipeline. Covers Build, Test (Fast), Lint, and Basic Security. This is the **Primary Source of Truth** for the health of the PR.
+*   `ci.yml`: The central CI pipeline. Covers Build, Fast Tests, and Linting. This is the **Primary Source of Truth** for the mergeability of the PR.
+    *   *Note:* While it includes a conditional `security` job (for `full-ci`), comprehensive security checks are managed by `security.yml`.
 *   `wgx-guard.yml`: Ensures the integrity and configuration of the `wgx` tool.
 *   `ci-tools.yml`: Ensures internal CI tools are built correctly.
 
@@ -25,7 +30,7 @@ This directory contains the CI/CD definitions for the HausKI project. To prevent
 *   `policy-ci.yml`: Validation of policy definitions.
 *   `ai-context-guard.yml`: Protection of the `.ai-context.yml` file.
 *   `validate-*.yml`: Schema validation (Events, Dev-Tooling).
-*   `secret-scan-gitleaks.yml`: Secret scanning.
+*   `secret-scan-gitleaks.yml`: Secret scanning (runs on PRs and pushes).
 *   `release.yml`: Release automation.
 *   `pr-heimgewebe-commands.yml`: ChatOps and PR interactions.
 *   `codex-review.yml`, `review-cycle-check.yml`: Review process logic.

--- a/.github/workflows/ci-tools.yml
+++ b/.github/workflows/ci-tools.yml
@@ -1,3 +1,4 @@
+# CLASS: baseline
 name: CI (tools)
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: CI (smart PR)
 
+# CLASS: baseline
 # ------------------------------------------------------------------------------
-# SEMANTIC CLASSIFICATION: BASELINE
-# Dieser Workflow ist die Baseline. Andere Workflows (z.B. heavy.yml, security.yml)
-# ergänzen ihn, ersetzen ihn nicht.
-# Siehe .github/workflows/README.md für Details.
+# This workflow is the Baseline. Other workflows (e.g., heavy.yml, security.yml)
+# supplement it, they do not replace it.
+# See .github/workflows/README.md for details.
 # ------------------------------------------------------------------------------
 
 on:

--- a/.github/workflows/contracts-validate.yml
+++ b/.github/workflows/contracts-validate.yml
@@ -1,3 +1,4 @@
+# CLASS: meta
 name: "contracts-validate"
 
 permissions:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,3 +1,4 @@
+# CLASS: meta
 name: contracts
 
 on: [push, pull_request]

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,3 +1,4 @@
+# CLASS: deepening
 name: coverage
 permissions:
   contents: read

--- a/.github/workflows/heavy.yml
+++ b/.github/workflows/heavy.yml
@@ -1,3 +1,4 @@
+# CLASS: deepening
 name: CI (heavy on demand)
 
 on:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,3 +1,4 @@
+# CLASS: deepening
 name: Link Check (Lychee)
 
 concurrency:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,3 +1,4 @@
+# CLASS: deepening
 name: security
 
 on:

--- a/.github/workflows/wgx-guard.yml
+++ b/.github/workflows/wgx-guard.yml
@@ -1,3 +1,4 @@
+# CLASS: baseline
 ---
 name: wgx-guard
 

--- a/.github/workflows/wgx-smoke.yml
+++ b/.github/workflows/wgx-smoke.yml
@@ -1,3 +1,4 @@
+# CLASS: deepening
 ---
 name: wgx-smoke
 permissions:


### PR DESCRIPTION
- Add .github/workflows/README.md classifying workflows into Baseline, Deepening, and Meta.
- Add comment header to ci.yml clarifying its role as the irreplaceable Baseline.

This addresses the "Drift-Gefahr" by explicitly defining the purpose and hierarchy of CI workflows without changing their logic.