### PR TITLE
docs: source system context from Systemkatalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,13 +551,14 @@ Für eine dauerhafte Installation kann `hauski` als `systemd`-Dienst konfigurier
 
 Ohne aktualisiertes `uv.lock` bricht CI mit einem klaren Hinweis ab.
 
-## Organismus-Kontext
+## Systemkontext
 
-Dieses Repository ist Teil des **Heimgewebe-Organismus**.
+Der aktuelle Zweck, Lifecycle-Status und die Beziehungen dieses Repositories zu anderen
+Heimgewebe-Systemen werden im [Systemkatalog](https://github.com/heimgewebe/systemkatalog) geführt. Die
+[gerenderte Systemübersicht](https://github.com/heimgewebe/systemkatalog/blob/main/rendered/system-catalog.md)
+ist die lesbare Gesamtsicht; die
+[maschinenlesbare Inventur](https://github.com/heimgewebe/systemkatalog/blob/main/registry/ecosystem/nodes.json)
+ist die Quelle für Automatisierung.
 
-Die übergeordnete Architektur, Achsen, Rollen und Contracts sind zentral beschrieben im
-👉 [`metarepo/docs/system/heimgewebe-organismus.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/system/heimgewebe-organismus.md)
-👉 [`metarepo/docs/system/heimgewebe-zielbild.md`](https://github.com/heimgewebe/metarepo/blob/main/docs/system/heimgewebe-zielbild.md).
-
-Alle Rollen-Definitionen, Datenflüsse und Contract-Zuordnungen dieses Repos
-sind dort verankert.
+Repositoryeigene Betriebs-, Daten- und Implementierungswahrheit bleibt in diesem Repository.
+Gemeinsame Contracts bleiben bei ihrer jeweiligen Primärquelle.

--- a/docs/hauski-guidance.md
+++ b/docs/hauski-guidance.md
@@ -1,28 +1,16 @@
-# hausKI-Guidance im Heimgewebe-Organismus
+# hausKI-Guidance im Heimgewebe-Systemverbund
 
-Dieses Dokument beschreibt, wie `hausKI` im Heimgewebe-Organismus arbeiten soll:
-
-- welche Signale es liest,
-- welche Contracts es respektiert,
-- wie Entscheidungen gefällt und protokolliert werden.
-
-Es baut auf dem Organismus-Dokument im Repository `heimgewebe/metarepo` auf.
-<!-- (`docs/heimgewebe-organismus.md` im Metarepo). -->
+Dieses Dokument beschreibt repositoryeigene Betriebs- und Contractregeln für `hausKI`.
+Der aktuelle Systemzweck, Lifecycle-Status und die Beziehungen zu anderen Komponenten werden
+im [Systemkatalog](https://github.com/heimgewebe/systemkatalog) geführt; dieses Dokument erzeugt
+keine zweite Rollenwahrheit.
 
 ---
 
-## 1. Rolle von hausKI im Organismus
+## 1. Rolle von hausKI
 
-Kurzfassung:
+Für `hausKI` gelten repositoryintern folgende Regeln:
 
-- `chronik` = Gedächtnis (Events)
-- `semantAH` = Sinnschicht (Insights)
-- `leitstand` = Sichtbarkeit (Digest)
-- `wgx` = Motorik (Kommandos)
-- `heimlern` = Lernen aus Feedback
-- **`hausKI` = Entscheider, der diese Schichten koordiniert**
-
-hausKI soll:
 
 1. Systemzustände aus den bestehenden Datenquellen lesen,
 2. Entscheidungen anhand von Playbooks und Policies treffen,
@@ -223,4 +211,4 @@ Auch wenn die konkrete Implementierung in Code erfolgt, folgt jedes Playbook gro
 - hausKI-Implementierung verweist in Kommentaren explizit auf relevante Abschnitte dieses Dokuments.
 
 Ziel: Entscheidungen von hausKI sind nicht „magisch“, sondern aus
-Organismus-Regeln und Contracts nachvollziehbar.
+Systemregeln und Contracts nachvollziehbar.


### PR DESCRIPTION
## Zweck

Die historisierte Metarepo-Organismusarchitektur darf keine aktuelle Rollenwahrheit für hausKI mehr liefern.

## Änderung

- README auf Systemkatalog als Primärquelle umgestellt
- statische Organ- und Koordinatorrollen aus der hausKI-Guidance entfernt
- Guidance auf repositoryeigene Betriebs- und Contractregeln begrenzt

## Prüfung

- Rustfmt und Clippy grün
- vollständiger Cargo-Workspace-Testlauf bestanden
- T006-Drift-, Ziel- und Whitespace-Gate bestanden

Bureau: `METAREPO-LEGACY-RECONCILIATION-V1-T006`