### PR TITLE
test: remove redundant metrics smoke borrow

### DIFF
--- a/crates/core/tests/metrics_smoke.rs
+++ b/crates/core/tests/metrics_smoke.rs
@@ -53,6 +53,6 @@ async fn metrics_endpoint_exposes_prometheus_text() {
         body.contains("# HELP") || body.contains("# TYPE"),
         "unexpected /metrics payload (length={}): first bytes: {:?}",
         body.len(),
-        &body.as_bytes().get(0..64)
+        body.as_bytes().get(0..64)
     );
 }


### PR DESCRIPTION
## Ursache

Rust 1.97 aktiviert `clippy::useless-borrows-in-formatting` unter `-D warnings`. Dadurch scheitert die bestehende HausKI-CI unabhängig von den Dokumentänderungen in PR #755.

## Änderung

Eine redundante Referenz in `crates/core/tests/metrics_smoke.rs` wird entfernt. Verhalten und Formatierungsausgabe bleiben unverändert.

## Prüfung

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p hauski-core --test metrics_smoke`
- `git diff --check`

Blockiert: `heimgewebe/hausKI#755`