### PR TITLE
fix(ci): restore Rust CI compatibility

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     timeout-minutes: 25
+    env:
+      # Last verified working nightly; unpinned 2026-07-14 ICEs in rustc_ast during doctest coverage.
+      COVERAGE_TOOLCHAIN: nightly-2026-07-06
 
     steps:
       - name: Checkout repository
@@ -50,18 +53,19 @@ jobs:
           cache-on-failure: true
           shared-key: ${{ runner.os }}-cov-${{ hashFiles('**/Cargo.lock') }}
 
-      # Coverage läuft komplett mit nightly + llvm-tools, um Versionsmischung zu vermeiden
-      - name: Install nightly with llvm-tools
+      # Coverage läuft komplett mit einer belegten nightly + llvm-tools, um Versionsmischung
+      # und unkontrollierte Compilerregressionen zu vermeiden.
+      - name: Install pinned nightly with llvm-tools
         run: |
           rustup set profile minimal
-          rustup toolchain install nightly --no-self-update --component llvm-tools-preview
-          rustup component list --toolchain nightly | grep llvm-tools
+          rustup toolchain install "$COVERAGE_TOOLCHAIN" --no-self-update --component llvm-tools-preview
+          rustup component list --toolchain "$COVERAGE_TOOLCHAIN" | grep llvm-tools
 
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked --version 0.6.9
 
       - name: Clean coverage profiles
-        run: cargo +nightly llvm-cov clean --workspace
+        run: cargo +"$COVERAGE_TOOLCHAIN" llvm-cov clean --workspace
 
       - name: Run coverage (focused)
         env:
@@ -75,7 +79,7 @@ jobs:
           PKGS="--package hauski-core --package hauski-indexd"
           echo "PKGS=$PKGS"
           # 1) Erzeuge HTML-Report (inkl. Testlauf)
-          cargo +nightly llvm-cov $PKGS \
+          cargo +"$COVERAGE_TOOLCHAIN" llvm-cov $PKGS \
             --all-features \
             --doctests \
             --fail-under-lines 65 \
@@ -83,7 +87,7 @@ jobs:
           echo "HTML report: target/llvm-cov/html/index.html"
 
           # 2) Erzeuge LCOV-Report aus den bereits gesammelten Profilen
-          cargo +nightly llvm-cov report \
+          cargo +"$COVERAGE_TOOLCHAIN" llvm-cov report \
             --lcov --output-path lcov.info
 
       - name: Upload HTML coverage

--- a/crates/core/tests/metrics_smoke.rs
+++ b/crates/core/tests/metrics_smoke.rs
@@ -53,6 +53,6 @@ async fn metrics_endpoint_exposes_prometheus_text() {
         body.contains("# HELP") || body.contains("# TYPE"),
         "unexpected /metrics payload (length={}): first bytes: {:?}",
         body.len(),
-        &body.as_bytes().get(0..64)
+        body.as_bytes().get(0..64)
     );
 }


### PR DESCRIPTION
## Ursache

Zwei unabhängige Toolchain-Regressionen blockieren aktuelle HausKI-PRs gegenseitig:

1. Der ungebundene Coverage-Nightly vom 14. Juli 2026 reproduziert einen internen rustc-Absturz während der Doctest-Coverage. Der letzte grüne Lauf vom 6. Juli nutzte rustc `3659db0d3`.
2. Rust 1.97 aktiviert `clippy::useless-borrows-in-formatting` unter `-D warnings` für eine bestehende redundante Referenz in `metrics_smoke.rs`.

Getrennte PRs konnten nicht grün werden: Der Coverage-Pin lief in das Clippy-Gate, der Clippy-Fix in den Coverage-ICE. Deshalb werden beide minimalen, bereits einzeln geprüften Änderungen in diesem Integrations-PR gemeinsam validiert.

## Änderungen

- Coverage auf `nightly-2026-07-06` pinnen
- alle Coverage-Kommandos an dieselbe Toolchain binden
- redundante Referenz in `crates/core/tests/metrics_smoke.rs` entfernen

## Prüfung

- gepinnter Channel löst exakt rustc `1.99.0-nightly (3659db0d3 2026-07-05)` auf
- Workflow-YAML gültig
- Rustfmt grün
- vollständiges Clippy mit `-D warnings` grün
- `git diff --check` grün

Supersedes: `heimgewebe/hausKI#756`
Blockiert: `heimgewebe/hausKI#755`